### PR TITLE
feat: [SRTP-340] Add cancellation test on webpage

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -50,19 +50,10 @@
 
 ### Did you update dependencies accordingly?
 
-Run:
-
-- `pipenv run pip freeze > requirements.txt`
-- `pipenv install -r requirements.txt`
-
-and check for changes.
-
-- [ ] Yes
-  - [ ] `requirements.txt`
-  - [ ] `Pipfile`
-  - [ ] `Pipfile.lock`
+- [ ] Yes (which requirements.txt did you update?)
+<!--- Describe which requirements.txt did you update -->
 - [ ] Not needed
-- [ ] No (_please provide further information_)
+
 
 ### Other information
 

--- a/.gitignore
+++ b/.gitignore
@@ -154,6 +154,9 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 
+# VS Code
+.vscode/
+
 # PyCharm
 #  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore

--- a/ux-tests/tests/conftest.py
+++ b/ux-tests/tests/conftest.py
@@ -4,7 +4,7 @@ from playwright.sync_api import sync_playwright
 @pytest.fixture(scope='session')
 def playwright_browser():
     with sync_playwright() as p:
-        browser = p.chromium.launch(headless=False)
+        browser = p.chromium.launch(headless=True)
         yield browser
         browser.close()
 

--- a/ux-tests/tests/conftest.py
+++ b/ux-tests/tests/conftest.py
@@ -1,0 +1,15 @@
+import pytest
+from playwright.sync_api import sync_playwright
+
+@pytest.fixture(scope='session')
+def playwright_browser():
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=False)
+        yield browser
+        browser.close()
+
+@pytest.fixture
+def page(playwright_browser):
+    page = playwright_browser.new_page()
+    yield page
+    page.close()

--- a/ux-tests/tests/test_cancel.py
+++ b/ux-tests/tests/test_cancel.py
@@ -1,0 +1,23 @@
+import allure
+from playwright.sync_api import expect
+from test_submission import test_rtp_form_submission
+
+
+@allure.feature('RTP Submission')
+@allure.story('RTP cancellation through web page')
+@allure.title('RTP form cancellation test')
+def test_rtp_form_cancellation(page):
+    test_rtp_form_submission(page)
+
+    page.click('button:has-text("Cancella richiesta")')
+
+    modal = page.get_by_role("dialog", name="Vuoi cancellare la richiesta?")
+    expect(modal).to_be_visible()
+
+    expect(page.locator('text=Vuoi cancellare la richiesta?')).to_be_visible()
+    expect(page.locator('text=Proseguendo, la richiesta di pagamento appena creata verrà cancellata.')).to_be_visible()
+
+    modal.locator('button:has-text("Cancella richiesta")').click()
+
+    cancellation_msg = page.locator('text=La richiesta è stata cancellata')
+    expect(cancellation_msg).to_be_visible()

--- a/ux-tests/tests/test_cancel.py
+++ b/ux-tests/tests/test_cancel.py
@@ -14,8 +14,8 @@ def test_rtp_form_cancellation(page):
     modal = page.get_by_role("dialog", name="Vuoi cancellare la richiesta?")
     expect(modal).to_be_visible()
 
-    expect(page.locator('text=Vuoi cancellare la richiesta?')).to_be_visible()
-    expect(page.locator('text=Proseguendo, la richiesta di pagamento appena creata verrà cancellata.')).to_be_visible()
+    expect(modal.locator('text=Vuoi cancellare la richiesta?')).to_be_visible()
+    expect(modal.locator('text=Proseguendo, la richiesta di pagamento appena creata verrà cancellata.')).to_be_visible()
 
     modal.locator('button:has-text("Cancella richiesta")').click()
 

--- a/ux-tests/tests/test_cancel.py
+++ b/ux-tests/tests/test_cancel.py
@@ -14,6 +14,9 @@ def test_rtp_form_cancellation(page):
     modal = page.get_by_role("dialog", name="Vuoi cancellare la richiesta?")
     expect(modal).to_be_visible()
 
+    expect(page.locator('text=Vuoi cancellare la richiesta?')).to_be_visible()
+    expect(page.locator('text=Proseguendo, la richiesta di pagamento appena creata verrà cancellata.')).to_be_visible()
+
     modal.locator('button:has-text("Cancella richiesta")').click()
 
     cancellation_msg = page.locator('text=La richiesta è stata cancellata')

--- a/ux-tests/tests/test_cancel.py
+++ b/ux-tests/tests/test_cancel.py
@@ -14,9 +14,6 @@ def test_rtp_form_cancellation(page):
     modal = page.get_by_role("dialog", name="Vuoi cancellare la richiesta?")
     expect(modal).to_be_visible()
 
-    expect(page.locator('text=Vuoi cancellare la richiesta?')).to_be_visible()
-    expect(page.locator('text=Proseguendo, la richiesta di pagamento appena creata verrà cancellata.')).to_be_visible()
-
     modal.locator('button:has-text("Cancella richiesta")').click()
 
     cancellation_msg = page.locator('text=La richiesta è stata cancellata')

--- a/ux-tests/tests/test_submission.py
+++ b/ux-tests/tests/test_submission.py
@@ -2,31 +2,13 @@ import re
 from datetime import datetime
 
 import allure
-import pytest
 from playwright.sync_api import expect
-from playwright.sync_api import sync_playwright
 
 from config.configuration import config
 from config.configuration import secrets
 from utils.dataset import generate_rtp_data
 
 page_url = config.landing_page_path
-
-
-@pytest.fixture(scope='session')
-def playwright_browser():
-    with sync_playwright() as p:
-        browser = p.chromium.launch(headless=True)
-        yield browser
-        browser.close()
-
-
-@pytest.fixture
-def page(playwright_browser):
-    page = playwright_browser.new_page()
-    yield page
-    page.close()
-
 
 @allure.feature('RTP Submission')
 @allure.story('RTP submission though web page')


### PR DESCRIPTION
### Description

This PR proposes adding tests to verify the cancellation feature of a submitted request.

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
add: test for request cancellation,
refactor: to centralize browser opening,
refactor: change request submission file name,
update: PR template.

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Aggregation level

<!--- Did you write a single reusable test case, or a full test suite?  -->

- [x] Test case
- [ ] Test suite

### Test type

- [x] Functional test
- [ ] Smoke test
- [ ] End to end
- [ ] Performance

### Type of changes

- [x] Add new test case/suite
- [ ] Modify existing test case/suite

### Test Results

- [ ] Success
- [x] Failure
- [ ] Poor performance
- [ ] Good performance

### Did you update secrets accordingly?

- [ ] Yes
  - [ ] `.secrets_template.yaml`
  - [ ] Pipelines' secure file
  - [ ] Confluence
- [x] Not needed
- [ ] No (_please provide further information_)

### Did you update dependencies accordingly?

Run:

- `pipenv run pip freeze > requirements.txt`
- `pipenv install -r requirements.txt`

and check for changes.

- [ ] Yes
  - [ ] `requirements.txt`
  - [ ] `Pipfile`
  - [ ] `Pipfile.lock`
- [ ] Not needed
- [ ] No (_please provide further information_)

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
