### PR TITLE
feat: [SRTP-348] Integrate existing callback tests

### DIFF
--- a/api/callback.py
+++ b/api/callback.py
@@ -3,7 +3,7 @@ import requests
 from config.configuration import config
 
 
-def srtp_callback(cert_path: str, key_path: str, rtp_payload):
+def srtp_callback(cert_path: str, key_path: str, rtp_payload, certificate_serial: str):
     return requests.post(
         cert=(
             cert_path,
@@ -11,7 +11,8 @@ def srtp_callback(cert_path: str, key_path: str, rtp_payload):
         ),
         url=config.callback_url,
         headers={
-            'Version': 'v1'
+            'Version': config.callback_api_version,
+            'X-certificate-client-Serial': certificate_serial,
         },
         json=rtp_payload,
         timeout=config.default_timeout

--- a/api/callback.py
+++ b/api/callback.py
@@ -11,8 +11,7 @@ def srtp_callback(cert_path: str, key_path: str, rtp_payload, certificate_serial
         ),
         url=config.callback_url,
         headers={
-            'Version': config.callback_api_version,
-            'X-certificate-client-Serial': certificate_serial,
+            'Version': config.callback_api_version
         },
         json=rtp_payload,
         timeout=config.default_timeout

--- a/api/callback.py
+++ b/api/callback.py
@@ -3,7 +3,7 @@ import requests
 from config.configuration import config
 
 
-def srtp_callback(cert_path: str, key_path: str, rtp_payload, certificate_serial: str):
+def srtp_callback(cert_path: str, key_path: str, rtp_payload):
     return requests.post(
         cert=(
             cert_path,

--- a/config.yaml
+++ b/config.yaml
@@ -20,6 +20,6 @@ activation_api_specification: 'https://raw.githubusercontent.com/pagopa/rtp-apis
 send_api_specification: 'https://raw.githubusercontent.com/pagopa/rtp-apis/refs/heads/main/src/rtp/api/pagopa/send.openapi.yaml'
 mcshared_auth_url: 'https://api-mcshared.uat.cstar.pagopa.it/auth/token'
 cbi_auth_url: 'https://stgcbiglobeopenbankingapigateway.nexi.it/auth/oauth/v2/token'
-cbi_send_url: 'https://stgcbiglobeopenbankingapigateway.nexi.it/srtp/sp/sepa-request-to-pay-requests'
+cbi_send_url: 'https://stgcbiglobeopenbankingapigateway.nexi.it/srtp/core/v1/1.0.0/srtp/sp/sepa-request-to-pay-requests'
 cancel_rtp_path: "rtps/{rtp_id}/cancel"
 cancel_api_version: 'v1'

--- a/config.yaml
+++ b/config.yaml
@@ -14,6 +14,7 @@ activation_base_url_path: "https://api-rtp.uat.cstar.pagopa.it/rtp/activation"
 send_rtp_path: "rtps"
 activation_path: "/activations"
 callback_url: "https://api-rtp-cb.uat.cstar.pagopa.it/rtp/cb/send"
+callback_api_version: 'v1'
 mock_service_provider_url: "https://api-rtp.uat.cstar.pagopa.it/rtp/mock/sepa-request-to-pay-requests"
 activation_api_specification: 'https://raw.githubusercontent.com/pagopa/rtp-apis/refs/heads/main/src/rtp/api/pagopa/activation.yaml'
 send_api_specification: 'https://raw.githubusercontent.com/pagopa/rtp-apis/refs/heads/main/src/rtp/api/pagopa/send.openapi.yaml'

--- a/functional-tests/tests/test_callback.py
+++ b/functional-tests/tests/test_callback.py
@@ -4,7 +4,6 @@ import pytest
 from api.callback import srtp_callback
 from config.configuration import config
 from config.configuration import secrets
-from utils.cryptography import get_serial_from_pem
 from utils.cryptography import pfx_to_pem
 from utils.dataset import generate_callback_data
 
@@ -22,14 +21,10 @@ def test_receive_rtp_callback():
                            config.cert_path,
                            config.key_path)
 
-    with open(cert, 'rb') as f:
-        pem_data = f.read()
-        certificate_serial = get_serial_from_pem(pem_data)
 
     callback_response = srtp_callback(rtp_payload=callback_data,
                                       cert_path=cert,
-                                      key_path=key,
-                                      certificate_serial=certificate_serial)
+                                      key_path=key)
     assert callback_response.status_code == 200, f'Error from callback, expected 200 got {callback_response.status_code}'
 
 
@@ -39,19 +34,14 @@ def test_receive_rtp_callback():
 @pytest.mark.callback
 @pytest.mark.unhappy_path
 def test_fail_send_rtp_callback_wrong_certificate_serial():
-    callback_data = generate_callback_data()
+    callback_data = generate_callback_data(BIC='MOCKSP01')
 
     cert, key = pfx_to_pem(secrets.debtor_service_provider_mock_PFX_base64,
                            secrets.debtor_service_provider_mock_PFX_password_base64,
                            config.cert_path,
                            config.key_path)
 
-    with open(cert, 'rb') as f:
-        pem_data = f.read()
-        certificate_serial = get_serial_from_pem(pem_data) + '0'
-
     callback_response = srtp_callback(rtp_payload=callback_data,
                                       cert_path=cert,
-                                      key_path=key,
-                                      certificate_serial=certificate_serial)
+                                      key_path=key)
     assert callback_response.status_code == 403, f'Expecting error from callback, expected 403 got {callback_response.status_code}'

--- a/functional-tests/tests/test_callback.py
+++ b/functional-tests/tests/test_callback.py
@@ -83,3 +83,41 @@ def test_fail_send_rtp_callback_wrong_certificate_serial_DS_08P_compliant():
                                       cert_path=cert,
                                       key_path=key)
     assert callback_response.status_code == 403, f'Expecting error from callback, expected 403 got {callback_response.status_code}'
+
+
+@allure.feature('RTP Callback')
+@allure.story('Service provider sends a callback referred to an RTP')
+@allure.title('Failed callback for non existing Service Provider - DS-04b compliant')
+@pytest.mark.callback
+@pytest.mark.unhappy_path
+def test_fail_send_rtp_callback_non_existing_service_provider_DS_04b_compliant():
+    callback_data = generate_callback_data_DS_04b_compliant(BIC='MOCKSP99')
+
+    cert, key = pfx_to_pem(secrets.debtor_service_provider_mock_PFX_base64,
+                           secrets.debtor_service_provider_mock_PFX_password_base64,
+                           config.cert_path,
+                           config.key_path)
+
+    callback_response = srtp_callback(rtp_payload=callback_data,
+                                      cert_path=cert,
+                                      key_path=key)
+    assert callback_response.status_code == 400, f'Expecting error from callback, expected 400 got {callback_response.status_code}'
+
+
+@allure.feature('RTP Callback')
+@allure.story('Service provider sends a callback referred to an RTP')
+@allure.title('Failed callback for non existing Service Provider - DS-08P compliant')
+@pytest.mark.callback
+@pytest.mark.unhappy_path
+def test_fail_send_rtp_callback_non_existing_service_provider_DS_08P_compliant():
+    callback_data = generate_callback_data_DS_08P_compliant(BIC='MOCKSP99')
+
+    cert, key = pfx_to_pem(secrets.debtor_service_provider_mock_PFX_base64,
+                           secrets.debtor_service_provider_mock_PFX_password_base64,
+                           config.cert_path,
+                           config.key_path)
+
+    callback_response = srtp_callback(rtp_payload=callback_data,
+                                      cert_path=cert,
+                                      key_path=key)
+    assert callback_response.status_code == 400, f'Expecting error from callback, expected 400 got {callback_response.status_code}'

--- a/functional-tests/tests/test_callback.py
+++ b/functional-tests/tests/test_callback.py
@@ -4,22 +4,54 @@ import pytest
 from api.callback import srtp_callback
 from config.configuration import config
 from config.configuration import secrets
+from utils.cryptography import get_serial_from_pem
 from utils.cryptography import pfx_to_pem
-from utils.dataset import generate_rtp_data
+from utils.dataset import generate_callback_data
 
 
 @allure.feature('RTP Callback')
-@allure.story('Service provider receives RTP callback')
-@allure.title('RTP callback is successfully received')
+@allure.story('Service provider sends a callback referred to an RTP')
+@allure.title('An RTP callback is successfully received')
 @pytest.mark.callback
 @pytest.mark.happy_path
 def test_receive_rtp_callback():
-    rtp_data = generate_rtp_data()
+    callback_data = generate_callback_data()
 
     cert, key = pfx_to_pem(secrets.debtor_service_provider_mock_PFX_base64,
                            secrets.debtor_service_provider_mock_PFX_password_base64,
                            config.cert_path,
                            config.key_path)
 
-    activation_response = srtp_callback(rtp_payload=rtp_data, cert_path=cert, key_path=key)
-    assert activation_response.status_code == 200, 'Error from callback'
+    with open(cert, 'rb') as f:
+        pem_data = f.read()
+        certificate_serial = get_serial_from_pem(pem_data)
+
+    callback_response = srtp_callback(rtp_payload=callback_data,
+                                      cert_path=cert,
+                                      key_path=key,
+                                      certificate_serial=certificate_serial)
+    assert callback_response.status_code == 200, f'Error from callback, expected 200 got {callback_response.status_code}'
+
+
+@allure.feature('RTP Callback')
+@allure.story('Service provider sends a callback referred to an RTP')
+@allure.title('Unauthorized callback due to wrong certificate serial')
+@pytest.mark.callback
+@pytest.mark.unhappy_path
+def test_fail_send_rtp_callback_wrong_certificate_serial():
+    callback_data = generate_callback_data()
+
+    cert, key = pfx_to_pem(secrets.debtor_service_provider_mock_PFX_base64,
+                           secrets.debtor_service_provider_mock_PFX_password_base64,
+                           config.cert_path,
+                           config.key_path)
+
+    with open(cert, 'rb') as f:
+        pem_data = f.read()
+        certificate_serial = get_serial_from_pem(pem_data) + '0'
+
+    callback_response = srtp_callback(rtp_payload=callback_data,
+                                      cert_path=cert,
+                                      key_path=key,
+                                      certificate_serial=certificate_serial)
+    assert callback_response.status_code == 403, f'Expecting error from callback, expected 403 got {callback_response.status_code}'

--- a/functional-tests/tests/test_callback.py
+++ b/functional-tests/tests/test_callback.py
@@ -5,7 +5,8 @@ from api.callback import srtp_callback
 from config.configuration import config
 from config.configuration import secrets
 from utils.cryptography import pfx_to_pem
-from utils.dataset import generate_callback_data
+from utils.dataset import generate_callback_data_DS_04b_compliant
+from utils.dataset import generate_static_callback_data_DS_08P_compliant
 
 
 @allure.feature('RTP Callback')
@@ -13,14 +14,32 @@ from utils.dataset import generate_callback_data
 @allure.title('An RTP callback is successfully received')
 @pytest.mark.callback
 @pytest.mark.happy_path
-def test_receive_rtp_callback():
-    callback_data = generate_callback_data()
+def test_receive_rtp_callback_DS_04b_compliant():
+    callback_data = generate_callback_data_DS_04b_compliant()
 
     cert, key = pfx_to_pem(secrets.debtor_service_provider_mock_PFX_base64,
                            secrets.debtor_service_provider_mock_PFX_password_base64,
                            config.cert_path,
                            config.key_path)
 
+    callback_response = srtp_callback(rtp_payload=callback_data,
+                                      cert_path=cert,
+                                      key_path=key)
+    assert callback_response.status_code == 200, f'Error from callback, expected 200 got {callback_response.status_code}'
+
+
+@allure.feature('RTP Callback')
+@allure.story('Service provider sends a callback referred to an RTP')
+@allure.title('An RTP callback is successfully received')
+@pytest.mark.callback
+@pytest.mark.happy_path
+def test_receive_rtp_callback_DS_08P_compliant():
+    callback_data = generate_static_callback_data_DS_08P_compliant()
+
+    cert, key = pfx_to_pem(secrets.debtor_service_provider_mock_PFX_base64,
+                           secrets.debtor_service_provider_mock_PFX_password_base64,
+                           config.cert_path,
+                           config.key_path)
 
     callback_response = srtp_callback(rtp_payload=callback_data,
                                       cert_path=cert,
@@ -33,8 +52,8 @@ def test_receive_rtp_callback():
 @allure.title('Unauthorized callback due to wrong certificate serial')
 @pytest.mark.callback
 @pytest.mark.unhappy_path
-def test_fail_send_rtp_callback_wrong_certificate_serial():
-    callback_data = generate_callback_data(BIC='MOCKSP01')
+def test_fail_send_rtp_callback_wrong_certificate_serial_DS_04b_compliant():
+    callback_data = generate_callback_data_DS_04b_compliant(BIC='MOCKSP01')
 
     cert, key = pfx_to_pem(secrets.debtor_service_provider_mock_PFX_base64,
                            secrets.debtor_service_provider_mock_PFX_password_base64,

--- a/functional-tests/tests/test_callback.py
+++ b/functional-tests/tests/test_callback.py
@@ -6,7 +6,7 @@ from config.configuration import config
 from config.configuration import secrets
 from utils.cryptography import pfx_to_pem
 from utils.dataset import generate_callback_data_DS_04b_compliant
-from utils.dataset import generate_static_callback_data_DS_08P_compliant
+from utils.dataset import generate_callback_data_DS_08P_compliant
 
 
 @allure.feature('RTP Callback')
@@ -34,7 +34,7 @@ def test_receive_rtp_callback_DS_04b_compliant():
 @pytest.mark.callback
 @pytest.mark.happy_path
 def test_receive_rtp_callback_DS_08P_compliant():
-    callback_data = generate_static_callback_data_DS_08P_compliant()
+    callback_data = generate_callback_data_DS_08P_compliant()
 
     cert, key = pfx_to_pem(secrets.debtor_service_provider_mock_PFX_base64,
                            secrets.debtor_service_provider_mock_PFX_password_base64,
@@ -54,6 +54,25 @@ def test_receive_rtp_callback_DS_08P_compliant():
 @pytest.mark.unhappy_path
 def test_fail_send_rtp_callback_wrong_certificate_serial_DS_04b_compliant():
     callback_data = generate_callback_data_DS_04b_compliant(BIC='MOCKSP01')
+
+    cert, key = pfx_to_pem(secrets.debtor_service_provider_mock_PFX_base64,
+                           secrets.debtor_service_provider_mock_PFX_password_base64,
+                           config.cert_path,
+                           config.key_path)
+
+    callback_response = srtp_callback(rtp_payload=callback_data,
+                                      cert_path=cert,
+                                      key_path=key)
+    assert callback_response.status_code == 403, f'Expecting error from callback, expected 403 got {callback_response.status_code}'
+
+
+@allure.feature('RTP Callback')
+@allure.story('Service provider sends a callback referred to an RTP')
+@allure.title('Unauthorized callback due to wrong certificate serial')
+@pytest.mark.callback
+@pytest.mark.unhappy_path
+def test_fail_send_rtp_callback_wrong_certificate_serial_DS_08P_compliant():
+    callback_data = generate_callback_data_DS_08P_compliant(BIC='MOCKSP01')
 
     cert, key = pfx_to_pem(secrets.debtor_service_provider_mock_PFX_base64,
                            secrets.debtor_service_provider_mock_PFX_password_base64,

--- a/functional-tests/tests/test_cancel_rtp.py
+++ b/functional-tests/tests/test_cancel_rtp.py
@@ -44,8 +44,8 @@ def test_cancel_rtp_success():
 
 
 @allure.feature('RTP Callback')
-@allure.story('Service provider receives RTP callback')
-@allure.title('RTP callback is successfully received')
+@allure.story('Service provider cancels RTP')
+@allure.title('RTP cancellation fails if ID does not exist')
 @pytest.mark.cancel
 @pytest.mark.unhappy_path
 def test_cancel_rtp_with_nonexistent_resource_id():

--- a/utils/cryptography.py
+++ b/utils/cryptography.py
@@ -1,10 +1,12 @@
 import base64
 import os
 
+from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.serialization import Encoding
 from cryptography.hazmat.primitives.serialization import NoEncryption
 from cryptography.hazmat.primitives.serialization import PrivateFormat
 from cryptography.hazmat.primitives.serialization.pkcs12 import load_key_and_certificates
+from cryptography.x509 import load_pem_x509_certificate
 
 
 def client_credentials_to_auth_token(client_id, client_secret):
@@ -35,3 +37,16 @@ def pfx_to_pem(base64_pfx, base64_password, cert_destination_path=None, key_dest
             ))
 
     return cert_destination_path, key_destination_path
+
+
+def get_serial_from_pem(pem_data):
+    # Load the certificate from PEM data
+    cert = load_pem_x509_certificate(pem_data, default_backend())
+
+    # Get the serial number as an integer
+    serial_int = cert.serial_number
+
+    # Convert to hex without '0x' prefix and ensure no separators
+    serial_hex = format(serial_int, 'x')
+
+    return serial_hex

--- a/utils/dataset.py
+++ b/utils/dataset.py
@@ -234,7 +234,7 @@ def generate_callback_data():
         },
         '_links': {
             'initialSepaRequestToPayUri': {
-                'href': 'https://api-rtp-cb.cstar.pagopa.it/rtp/cb/requests/123456789-original-req-001',
+                'href': 'https://api-rtp-cb.uat.cstar.pagopa.it/rtp/cb/requests/123456789-original-req-001',
                 'templated': False
             }
         }

--- a/utils/dataset.py
+++ b/utils/dataset.py
@@ -241,7 +241,7 @@ def generate_callback_data_DS_04b_compliant(BIC: str = 'MOCKSP04') -> dict:
     }
 
 
-def generate_static_callback_data_DS_08P_compliant(BIC: str = 'MOCKSP04') -> dict:
+def generate_callback_data_DS_08P_compliant(BIC: str = 'MOCKSP04') -> dict:
     return {
         'resourceId': 'TestRtpMessageJZixUlWE3uYcb4k3lF4',
         'AsynchronousSepaRequestToPayResponse': {

--- a/utils/dataset.py
+++ b/utils/dataset.py
@@ -209,7 +209,7 @@ def generate_cbi_rtp_data(rtp_data: dict = None) -> dict:
     }
 
 
-def generate_callback_data():
+def generate_callback_data(BIC: str = 'MOCKSP04') -> dict:
     return {
         'resourceId': '456789123-rtp-response-001',
         'AsynchronousSepaRequestToPayResponse': {
@@ -220,7 +220,7 @@ def generate_callback_data():
                     'InitgPty': {
                         'Id': {
                             'OrgId': {
-                                'AnyBIC': 'MOCKSP04'
+                                'AnyBIC': BIC
                             }
                         }
                     }

--- a/utils/dataset.py
+++ b/utils/dataset.py
@@ -210,13 +210,20 @@ def generate_cbi_rtp_data(rtp_data: dict = None) -> dict:
 
 
 def generate_callback_data_DS_04b_compliant(BIC: str = 'MOCKSP04') -> dict:
+    message_id = str(uuid.uuid4())
+    resource_id = f'TestRtpMessage{generate_random_string(16)}'
+    original_msg_id = f'TestRtpMessage{generate_random_string(20)}'
+
+    create_time = datetime.now().strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+    original_time = (datetime.now() + timedelta(minutes=1)).strftime('%Y-%m-%dT%H:%M:%SZ')
+
     return {
-        'resourceId': '456789123-rtp-response-001',
+        'resourceId': resource_id,
         'AsynchronousSepaRequestToPayResponse': {
             'CdtrPmtActvtnReqStsRpt': {
                 'GrpHdr': {
-                    'MsgId': 'RESPONSE-MSG-001',
-                    'CreDtTm': '2025-03-21T10:15:30',
+                    'MsgId': message_id,
+                    'CreDtTm': create_time,
                     'InitgPty': {
                         'Id': {
                             'OrgId': {
@@ -226,15 +233,15 @@ def generate_callback_data_DS_04b_compliant(BIC: str = 'MOCKSP04') -> dict:
                     }
                 },
                 'OrgnlGrpInfAndSts': {
-                    'OrgnlMsgId': 'ORIGINAL-REQ-001',
+                    'OrgnlMsgId': original_msg_id,
                     'OrgnlMsgNmId': 'pain.013.001.08',
-                    'OrgnlCreDtTm': '2025-03-20T14:30:00'
+                    'OrgnlCreDtTm': original_time
                 }
             }
         },
         '_links': {
             'initialSepaRequestToPayUri': {
-                'href': 'https://api-rtp-cb.uat.cstar.pagopa.it/rtp/cb/requests/123456789-original-req-001',
+                'href': f'https://api-rtp-cb.uat.cstar.pagopa.it/rtp/cb/requests/{resource_id}',
                 'templated': False
             }
         }
@@ -242,15 +249,27 @@ def generate_callback_data_DS_04b_compliant(BIC: str = 'MOCKSP04') -> dict:
 
 
 def generate_callback_data_DS_08P_compliant(BIC: str = 'MOCKSP04') -> dict:
+    message_id = str(uuid.uuid4())
+    resource_id = f'TestRtpMessage{generate_random_string(16)}'
+    original_msg_id = f'TestRtpMessage{generate_random_string(20)}'
+    transaction_id = f'RTP-{generate_random_string(9)}-{int(datetime.now().timestamp() * 1000)}'
+
+    create_time = datetime.now().strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+    original_time = (datetime.now() + timedelta(minutes=1)).strftime('%Y-%m-%dT%H:%M:%SZ')
+
+    amount = round(random.uniform(1, 999999), 2)
+    expiry_date = (datetime.now() + timedelta(days=random.randint(1, 30))).strftime('%Y-%m-%d')
+    execution_date = (datetime.now() + timedelta(days=random.randint(1, 15))).strftime('%Y-%m-%d')
+
     return {
-        'resourceId': 'TestRtpMessageJZixUlWE3uYcb4k3lF4',
+        'resourceId': resource_id,
         'AsynchronousSepaRequestToPayResponse': {
-            'resourceId': 'TestRtpMessageJZixUlWE3uYcb4k3lF4',
+            'resourceId': resource_id,
             'Document': {
                 'CdtrPmtActvtnReqStsRpt': {
                     'GrpHdr': {
-                        'MsgId': '6588c58bcba84b0382422d45e5d04257',
-                        'CreDtTm': '2025-03-27T14:10:16.972736305Z',
+                        'MsgId': message_id,
+                        'CreDtTm': create_time,
                         'InitgPty': {
                             'Id': {
                                 'OrgId': {
@@ -260,17 +279,17 @@ def generate_callback_data_DS_08P_compliant(BIC: str = 'MOCKSP04') -> dict:
                         }
                     },
                     'OrgnlGrpInfAndSts': {
-                        'OrgnlMsgId': 'TestRtpMessageRP4El6L3npCOG9cbS8D',
+                        'OrgnlMsgId': original_msg_id,
                         'OrgnlMsgNmId': 'pain.013.001.07',
-                        'OrgnlCreDtTm': '2025-03-27T15:10:11Z'
+                        'OrgnlCreDtTm': original_time
                     },
                     'OrgnlPmtInfAndSts': [
                         {
-                            'OrgnlPmtInfId': 'ab85fbb7a48a4a669b5436ee5b497036',
+                            'OrgnlPmtInfId': str(uuid.uuid4()),
                             'TxInfAndSts': {
-                                'StsId': '6588c58bcba84b0382422d45e5d04257',
-                                'OrgnlInstrId': 'TestRtpMessageZaGCFHXTNi4kaFainM',
-                                'OrgnlEndToEndId': '302001234876234678',
+                                'StsId': message_id,
+                                'OrgnlInstrId': f'TestRtpMessage{generate_random_string(20)}',
+                                'OrgnlEndToEndId': ''.join(random.choices('0123456789', k=18)),
                                 'TxSts': 'RJCT',
                                 'StsRsnInf': {
                                     'Orgtr': {
@@ -286,23 +305,23 @@ def generate_callback_data_DS_08P_compliant(BIC: str = 'MOCKSP04') -> dict:
                                         'SvcLvl': {'Cd': 'SRTP'},
                                         'LclInstrm': {'Prtry': 'NOTPROVIDED'}
                                     },
-                                    'RmtInf': {'Ustrd': 'ATS001/TARI 2025 rata unica'},
+                                    'RmtInf': {'Ustrd': fake.sentence()},
                                     'Cdtr': {
                                         'Id': {
                                             'OrgId': {
                                                 'Othr': {
-                                                    'Id': 'RTP-O5FCa40wJH-1743084611744',
+                                                    'Id': transaction_id,
                                                     'SchmeNm': {'Cd': 'BOID'}
                                                 }
                                             }
                                         },
-                                        'Nm': 'test-creditor'
+                                        'Nm': fake.company()
                                     },
                                     'Dbtr': {
                                         'Id': {
                                             'PrvtId': {
                                                 'Othr': {
-                                                    'Id': 'RTP-iIMMmCHVUr-1743084611744',
+                                                    'Id': transaction_id,
                                                     'SchmeNm': {'Cd': 'POID'}
                                                 }
                                             }
@@ -316,15 +335,16 @@ def generate_callback_data_DS_08P_compliant(BIC: str = 'MOCKSP04') -> dict:
                                     },
                                     'CdtrAcct': {
                                         'Id': {
-                                            'IBAN': 'IT81E0300203280398564542723'
+                                            'IBAN': IBAN.generate('IT', bank_code='00000', account_code=str(
+                                                round(random.random() * math.pow(10, 10))) + '99').compact
                                         }
                                     },
-                                    'Amt': {'InstdAmt': 122},
+                                    'Amt': {'InstdAmt': amount},
                                     'ReqdExctnDt': {
-                                        'Dt': '2025-03-24Z'
+                                        'Dt': f'{execution_date}Z'
                                     },
                                     'XpryDt': {
-                                        'Dt': '2025-04-26Z'
+                                        'Dt': f'{expiry_date}Z'
                                     }
                                 }
                             }
@@ -334,3 +354,7 @@ def generate_callback_data_DS_08P_compliant(BIC: str = 'MOCKSP04') -> dict:
             }
         }
     }
+
+
+def generate_random_string(length: int) -> str:
+    return ''.join(random.choices(string.ascii_letters + string.digits, k=length))

--- a/utils/dataset.py
+++ b/utils/dataset.py
@@ -207,3 +207,35 @@ def generate_cbi_rtp_data(rtp_data: dict = None) -> dict:
         },
         'callbackUrl': 'http://spsrtp.api.uat.cstar.pagopa.it'
     }
+
+
+def generate_callback_data():
+    return {
+        'resourceId': '456789123-rtp-response-001',
+        'AsynchronousSepaRequestToPayResponse': {
+            'CdtrPmtActvtnReqStsRpt': {
+                'GrpHdr': {
+                    'MsgId': 'RESPONSE-MSG-001',
+                    'CreDtTm': '2025-03-21T10:15:30',
+                    'InitgPty': {
+                        'Id': {
+                            'OrgId': {
+                                'AnyBIC': 'MOCKSP04'
+                            }
+                        }
+                    }
+                },
+                'OrgnlGrpInfAndSts': {
+                    'OrgnlMsgId': 'ORIGINAL-REQ-001',
+                    'OrgnlMsgNmId': 'pain.013.001.08',
+                    'OrgnlCreDtTm': '2025-03-20T14:30:00'
+                }
+            }
+        },
+        '_links': {
+            'initialSepaRequestToPayUri': {
+                'href': 'https://api-rtp-cb.cstar.pagopa.it/rtp/cb/requests/123456789-original-req-001',
+                'templated': False
+            }
+        }
+    }

--- a/utils/dataset.py
+++ b/utils/dataset.py
@@ -209,7 +209,7 @@ def generate_cbi_rtp_data(rtp_data: dict = None) -> dict:
     }
 
 
-def generate_callback_data(BIC: str = 'MOCKSP04') -> dict:
+def generate_callback_data_DS_04b_compliant(BIC: str = 'MOCKSP04') -> dict:
     return {
         'resourceId': '456789123-rtp-response-001',
         'AsynchronousSepaRequestToPayResponse': {
@@ -236,6 +236,101 @@ def generate_callback_data(BIC: str = 'MOCKSP04') -> dict:
             'initialSepaRequestToPayUri': {
                 'href': 'https://api-rtp-cb.uat.cstar.pagopa.it/rtp/cb/requests/123456789-original-req-001',
                 'templated': False
+            }
+        }
+    }
+
+
+def generate_static_callback_data_DS_08P_compliant(BIC: str = 'MOCKSP04') -> dict:
+    return {
+        'resourceId': 'TestRtpMessageJZixUlWE3uYcb4k3lF4',
+        'AsynchronousSepaRequestToPayResponse': {
+            'resourceId': 'TestRtpMessageJZixUlWE3uYcb4k3lF4',
+            'Document': {
+                'CdtrPmtActvtnReqStsRpt': {
+                    'GrpHdr': {
+                        'MsgId': '6588c58bcba84b0382422d45e5d04257',
+                        'CreDtTm': '2025-03-27T14:10:16.972736305Z',
+                        'InitgPty': {
+                            'Id': {
+                                'OrgId': {
+                                    'AnyBIC': BIC
+                                }
+                            }
+                        }
+                    },
+                    'OrgnlGrpInfAndSts': {
+                        'OrgnlMsgId': 'TestRtpMessageRP4El6L3npCOG9cbS8D',
+                        'OrgnlMsgNmId': 'pain.013.001.07',
+                        'OrgnlCreDtTm': '2025-03-27T15:10:11Z'
+                    },
+                    'OrgnlPmtInfAndSts': [
+                        {
+                            'OrgnlPmtInfId': 'ab85fbb7a48a4a669b5436ee5b497036',
+                            'TxInfAndSts': {
+                                'StsId': '6588c58bcba84b0382422d45e5d04257',
+                                'OrgnlInstrId': 'TestRtpMessageZaGCFHXTNi4kaFainM',
+                                'OrgnlEndToEndId': '302001234876234678',
+                                'TxSts': 'RJCT',
+                                'StsRsnInf': {
+                                    'Orgtr': {
+                                        'Id': {
+                                            'OrgId': {
+                                                'AnyBIC': BIC
+                                            }
+                                        }
+                                    }
+                                },
+                                'OrgnlTxRef': {
+                                    'PmtTpInf': {
+                                        'SvcLvl': {'Cd': 'SRTP'},
+                                        'LclInstrm': {'Prtry': 'NOTPROVIDED'}
+                                    },
+                                    'RmtInf': {'Ustrd': 'ATS001/TARI 2025 rata unica'},
+                                    'Cdtr': {
+                                        'Id': {
+                                            'OrgId': {
+                                                'Othr': {
+                                                    'Id': 'RTP-O5FCa40wJH-1743084611744',
+                                                    'SchmeNm': {'Cd': 'BOID'}
+                                                }
+                                            }
+                                        },
+                                        'Nm': 'test-creditor'
+                                    },
+                                    'Dbtr': {
+                                        'Id': {
+                                            'PrvtId': {
+                                                'Othr': {
+                                                    'Id': 'RTP-iIMMmCHVUr-1743084611744',
+                                                    'SchmeNm': {'Cd': 'POID'}
+                                                }
+                                            }
+                                        }
+                                    },
+                                    'DbtrAgt': {
+                                        'FinInstnId': {'BICFI': BIC}
+                                    },
+                                    'CdtrAgt': {
+                                        'FinInstnId': {'BICFI': BIC}
+                                    },
+                                    'CdtrAcct': {
+                                        'Id': {
+                                            'IBAN': 'IT81E0300203280398564542723'
+                                        }
+                                    },
+                                    'Amt': {'InstdAmt': 122},
+                                    'ReqdExctnDt': {
+                                        'Dt': '2025-03-24Z'
+                                    },
+                                    'XpryDt': {
+                                        'Dt': '2025-04-26Z'
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                }
             }
         }
     }

--- a/ux-tests/tests/test_cancel.py
+++ b/ux-tests/tests/test_cancel.py
@@ -11,7 +11,7 @@ def test_rtp_form_cancellation(page):
 
     page.click('button:has-text("Cancella richiesta")')
 
-    modal = page.get_by_role("dialog", name="Vuoi cancellare la richiesta?")
+    modal = page.get_by_role('dialog', name='Vuoi cancellare la richiesta?')
     expect(modal).to_be_visible()
 
     expect(modal.locator('text=Vuoi cancellare la richiesta?')).to_be_visible()


### PR DESCRIPTION
### Description
This PR proposes to add tests on callback API executed with various certificate/service provider combination.
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
- add tests
- update config
<!--- Describe your changes in detail -->

### Motivation and context
With this change we can check if our service receives correctly a callback from service providers.
<!--- Why is this change required? What problem does it solve? -->

### Aggregation level

<!--- Did you write a single reusable test case, or a full test suite?  -->

- [ ] Test case
- [x] Test suite

### Test type

- [x] Functional test
- [ ] Smoke test
- [ ] End to end
- [ ] Performance

### Type of changes

- [x] Add new test case/suite
- [ ] Modify existing test case/suite

### Test Results

- [x] Success
- [ ] Failure
- [ ] Poor performance
- [ ] Good performance

### Did you update secrets accordingly?

- [ ] Yes
  - [ ] `.secrets_template.yaml`
  - [ ] Pipelines' secure file
  - [ ] Confluence
- [ ] Not needed
- [ ] No (_please provide further information_)

### Did you update dependencies accordingly?

Run:

- `pipenv run pip freeze > requirements.txt`
- `pipenv install -r requirements.txt`

and check for changes.

- [ ] Yes
  - [ ] `requirements.txt`
  - [ ] `Pipfile`
  - [ ] `Pipfile.lock`
- [ ] Not needed
- [ ] No (_please provide further information_)

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
