### PR TITLE
feat: [SRTP-465] add test plan for service_provider_registry

### DIFF
--- a/api/service_providers_registry.py
+++ b/api/service_providers_registry.py
@@ -1,0 +1,19 @@
+import uuid
+
+import requests
+
+from config.configuration import config
+
+SERVICE_PROVIDERS_URL = f"{config.rtp_creation_base_url_path}{config.service_providers_registry}"
+
+def get_service_providers_registry(access_token: str):
+
+    return requests.get(
+                url=SERVICE_PROVIDERS_URL,
+                headers={
+                    'Authorization': access_token,
+                    'Version': config.service_providers_registry_api_version,
+                    'RequestId': str(uuid.uuid4())
+                },
+                timeout=config.default_timeout
+            )

--- a/config.yaml
+++ b/config.yaml
@@ -25,3 +25,5 @@ cbi_auth_url: 'https://stgcbiglobeopenbankingapigateway.nexi.it/auth/oauth/v2/to
 cbi_send_url: 'https://stgcbiglobeopenbankingapigateway.nexi.it/srtp/core/v1/1.0.0/srtp/sp/sepa-request-to-pay-requests'
 cancel_rtp_path: "rtps/{rtp_id}/cancel"
 cancel_api_version: 'v1'
+service_providers_registry: 'service_providers/service-providers'
+service_providers_registry_api_version: 'v1'

--- a/functional-tests/tests/test_payees_registry.py
+++ b/functional-tests/tests/test_payees_registry.py
@@ -26,6 +26,7 @@ class TestPayeesRegistry:
     @pytest.mark.happy_path
     def test_get_payees_success(self):
         response = get_payee_registry(self.access_token)
+        print('self.access_token', self.access_token)
 
         assert response.status_code == 200
         data = response.json()
@@ -75,3 +76,5 @@ class TestPayeesRegistry:
         response = get_payee_registry('invalid_token')
 
         assert response.status_code == 401
+
+#generate test on group

--- a/functional-tests/tests/test_payees_registry.py
+++ b/functional-tests/tests/test_payees_registry.py
@@ -26,7 +26,6 @@ class TestPayeesRegistry:
     @pytest.mark.happy_path
     def test_get_payees_success(self):
         response = get_payee_registry(self.access_token)
-        print('self.access_token', self.access_token)
 
         assert response.status_code == 200
         data = response.json()

--- a/functional-tests/tests/test_service_providers_registry.py
+++ b/functional-tests/tests/test_service_providers_registry.py
@@ -23,7 +23,6 @@ class TestServiceProvidersRegistry:
     @pytest.mark.happy_path
     def test_get_service_providers_success(self):
         response = get_service_providers_registry(self.access_token)
-        print('self.access_token', self.access_token)
 
         assert response.status_code == 200
         data = response.json()

--- a/functional-tests/tests/test_service_providers_registry.py
+++ b/functional-tests/tests/test_service_providers_registry.py
@@ -1,0 +1,96 @@
+import allure
+import pytest
+
+from api.auth import get_access_token
+from api.auth import get_valid_access_token
+from api.service_providers_registry import get_service_providers_registry
+from config.configuration import config
+from config.configuration import secrets
+
+
+@allure.feature('Service Providers Registry')
+@allure.story('pagoPA retrieves service providers registry')
+class TestServiceProvidersRegistry:
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.access_token = get_valid_access_token(
+            client_id=secrets.pagopa_integration.client_id,
+            client_secret=secrets.pagopa_integration.client_secret,
+            access_token_function=get_access_token
+        )
+
+    @allure.title('Get list of service providers successfully')
+    @pytest.mark.happy_path
+    def test_get_service_providers_success(self):
+        response = get_service_providers_registry(self.access_token)
+        print('self.access_token', self.access_token)
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Verify top-level structure
+        assert 'tsps' in data, "Response should contain 'tsps' array"
+        assert 'sps' in data, "Response should contain 'sps' array"
+
+        assert isinstance(data['tsps'], list), "'tsps' should be a list"
+        assert isinstance(data['sps'], list), "'sps' should be a list"
+
+        assert len(data['tsps']) > 0, "Expected at least one technical service provider"
+        assert len(data['sps']) > 0, "Expected at least one service provider"
+
+        # Verify TSP structure
+        for tsp in data['tsps']:
+            assert 'id' in tsp, "TSP should have an id"
+            assert 'name' in tsp, "TSP should have a name"
+            assert 'service_endpoint' in tsp, "TSP should have a service_endpoint"
+            assert 'certificate_serial_number' in tsp, "TSP should have a certificate_serial_number"
+            assert 'mtls_enabled' in tsp, "TSP should have mtls_enabled flag"
+
+            assert isinstance(tsp['id'], str), "TSP id should be a string"
+            assert isinstance(tsp['name'], str), "TSP name should be a string"
+            assert isinstance(tsp['service_endpoint'], str), "TSP service_endpoint should be a string"
+            assert isinstance(tsp['certificate_serial_number'], str), "TSP certificate_serial_number should be a string"
+            assert isinstance(tsp['mtls_enabled'], bool), "TSP mtls_enabled should be a boolean"
+
+            # Check oauth2 config if present
+            if 'oauth2' in tsp:
+                oauth2 = tsp['oauth2']
+                assert 'token_endpoint' in oauth2, "OAuth2 should have token_endpoint"
+                assert 'method' in oauth2, "OAuth2 should have method"
+                assert isinstance(oauth2['token_endpoint'], str), "OAuth2 token_endpoint should be a string"
+                assert isinstance(oauth2['method'], str), "OAuth2 method should be a string"
+
+                # Optional fields check
+                if 'credentials_transport_mode' in oauth2:
+                    assert isinstance(oauth2['credentials_transport_mode'], str)
+                if 'client_id' in oauth2:
+                    assert isinstance(oauth2['client_id'], str)
+                if 'scope' in oauth2:
+                    assert isinstance(oauth2['scope'], str)
+                if 'mtls_enabled' in oauth2:
+                    assert isinstance(oauth2['mtls_enabled'], bool)
+
+        # Verify SP structure
+        for sp in data['sps']:
+            assert 'id' in sp, "SP should have an id"
+            assert 'name' in sp, "SP should have a name"
+            assert 'tsp_id' in sp, "SP should have a tsp_id"
+
+            assert isinstance(sp['id'], str), "SP id should be a string"
+            assert isinstance(sp['name'], str), "SP name should be a string"
+            assert isinstance(sp['tsp_id'], str), "SP tsp_id should be a string"
+
+            if 'role' in sp:
+                assert isinstance(sp['role'], str), "SP role should be a string"
+
+            # Verify each SP has a corresponding TSP
+            tsp_ids = [tsp['id'] for tsp in data['tsps']]
+            assert sp['tsp_id'] in tsp_ids, f"SP's tsp_id '{sp['tsp_id']}' should reference an existing TSP"
+
+    @allure.title('Get payees with invalid authorization')
+    @pytest.mark.unhappy_path
+    def test_get_payees_invalid_auth(self):
+        response = get_service_providers_registry('invalid_token')
+
+        assert response.status_code == 401

--- a/functional-tests/tests/test_service_providers_registry.py
+++ b/functional-tests/tests/test_service_providers_registry.py
@@ -4,7 +4,6 @@ import pytest
 from api.auth import get_access_token
 from api.auth import get_valid_access_token
 from api.service_providers_registry import get_service_providers_registry
-from config.configuration import config
 from config.configuration import secrets
 
 
@@ -29,7 +28,6 @@ class TestServiceProvidersRegistry:
         assert response.status_code == 200
         data = response.json()
 
-        # Verify top-level structure
         assert 'tsps' in data, "Response should contain 'tsps' array"
         assert 'sps' in data, "Response should contain 'sps' array"
 
@@ -39,7 +37,6 @@ class TestServiceProvidersRegistry:
         assert len(data['tsps']) > 0, "Expected at least one technical service provider"
         assert len(data['sps']) > 0, "Expected at least one service provider"
 
-        # Verify TSP structure
         for tsp in data['tsps']:
             assert 'id' in tsp, "TSP should have an id"
             assert 'name' in tsp, "TSP should have a name"
@@ -53,7 +50,6 @@ class TestServiceProvidersRegistry:
             assert isinstance(tsp['certificate_serial_number'], str), "TSP certificate_serial_number should be a string"
             assert isinstance(tsp['mtls_enabled'], bool), "TSP mtls_enabled should be a boolean"
 
-            # Check oauth2 config if present
             if 'oauth2' in tsp:
                 oauth2 = tsp['oauth2']
                 assert 'token_endpoint' in oauth2, "OAuth2 should have token_endpoint"
@@ -61,7 +57,6 @@ class TestServiceProvidersRegistry:
                 assert isinstance(oauth2['token_endpoint'], str), "OAuth2 token_endpoint should be a string"
                 assert isinstance(oauth2['method'], str), "OAuth2 method should be a string"
 
-                # Optional fields check
                 if 'credentials_transport_mode' in oauth2:
                     assert isinstance(oauth2['credentials_transport_mode'], str)
                 if 'client_id' in oauth2:
@@ -71,7 +66,6 @@ class TestServiceProvidersRegistry:
                 if 'mtls_enabled' in oauth2:
                     assert isinstance(oauth2['mtls_enabled'], bool)
 
-        # Verify SP structure
         for sp in data['sps']:
             assert 'id' in sp, "SP should have an id"
             assert 'name' in sp, "SP should have a name"
@@ -84,7 +78,6 @@ class TestServiceProvidersRegistry:
             if 'role' in sp:
                 assert isinstance(sp['role'], str), "SP role should be a string"
 
-            # Verify each SP has a corresponding TSP
             tsp_ids = [tsp['id'] for tsp in data['tsps']]
             assert sp['tsp_id'] in tsp_ids, f"SP's tsp_id '{sp['tsp_id']}' should reference an existing TSP"
 


### PR DESCRIPTION
### Description

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
This PR adds end-to-end support for retrieving the service providers registry.

### Motivation and context
This PR adds tests to verify the correct retrieval of the service providers JSON file content.

<!--- Why is this change required? What problem does it solve? -->

### Aggregation level

<!--- Did you write a single reusable test case, or a full test suite?  -->

- [x] Test case
- [ ] Test suite

### Test type

- [x] Functional test
- [ ] Smoke test
- [x] End to end
- [ ] Performance

### Type of changes

- [x] Add new test case/suite
- [ ] Modify existing test case/suite

### Test Results

- [x] Success
- [ ] Failure
- [ ] Poor performance
- [ ] Good performance

### Did you update secrets accordingly?

- [ ] Yes
  - [ ] `.secrets_template.yaml`
  - [ ] Pipelines' secure file
  - [ ] Confluence
- [x] Not needed
- [ ] No (_please provide further information_)

### Did you update dependencies accordingly?

- [ ] Yes (which requirements.txt did you update?)
<!--- Describe which requirements.txt did you update -->
- [x] Not needed


### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
