### PR TITLE
feat: [SRTP-670] add tests get activation by activationID

### DIFF
--- a/api/activation.py
+++ b/api/activation.py
@@ -5,7 +5,7 @@ import requests
 from config.configuration import config
 
 ACTIVATION_URL = config.activation_base_url_path + config.activation_path
-
+ACTIVATION_BY_ID_URL = config.activation_base_url_path + config.activation_by_id_path
 
 def activate(access_token: str, payer_fiscal_code: str, service_provider_id: str):
     """API to activate a debtor to receive RTP
@@ -40,6 +40,18 @@ def get_activation_by_payer_id(access_token: str, payer_fiscal_code: str):
             'Version': 'v1',
             'RequestId': str(uuid.uuid4()),
             'PayerId': payer_fiscal_code
+        },
+        timeout=config.default_timeout
+    )
+
+def get_activation_by_id(access_token: str, activation_id: str):
+    """API to get activation by activationId."""
+    return requests.get(
+        url=ACTIVATION_BY_ID_URL.format(activationId=activation_id),
+        headers={
+            'Authorization': f'{access_token}',
+            'Version': 'v1',
+            'RequestId': str(uuid.uuid4())
         },
         timeout=config.default_timeout
     )

--- a/config.yaml
+++ b/config.yaml
@@ -31,3 +31,4 @@ get_rtp_path: "rtps/{rtpId}"
 get_api_version: 'v1'
 service_providers_registry: 'service_providers/service-providers'
 service_providers_registry_api_version: 'v1'
+activation_by_id_path: "/activations/{activationId}"

--- a/functional-tests/tests/test_activation.py
+++ b/functional-tests/tests/test_activation.py
@@ -1,11 +1,12 @@
+import uuid
 from datetime import datetime
 
 import allure
 import pytest
-import uuid
 
 from api.activation import activate
-from api.activation import get_activation_by_payer_id, get_activation_by_id
+from api.activation import get_activation_by_id
+from api.activation import get_activation_by_payer_id
 from api.auth import get_access_token
 from api.auth import get_valid_access_token
 from config.configuration import config

--- a/functional-tests/tests/test_activation.py
+++ b/functional-tests/tests/test_activation.py
@@ -2,9 +2,10 @@ from datetime import datetime
 
 import allure
 import pytest
+import uuid
 
 from api.activation import activate
-from api.activation import get_activation_by_payer_id
+from api.activation import get_activation_by_payer_id, get_activation_by_id
 from api.auth import get_access_token
 from api.auth import get_valid_access_token
 from config.configuration import config
@@ -42,6 +43,40 @@ def test_activate_debtor():
 
     try:
         datetime.strptime(res.json()['effectiveActivationDate'], '%Y-%m-%dT%H:%M:%S.%f')
+    except ValueError:
+        assert False, 'Invalid date format'
+
+
+@allure.feature('Activation')
+@allure.story('Get Debtor activation by ID')
+@allure.title('A debtor is activated and retrieved by activation id')
+@pytest.mark.auth
+@pytest.mark.activation
+@pytest.mark.happy_path
+def test_get_activation_by_id():
+    access_token = get_valid_access_token(
+        client_id=secrets.debtor_service_provider.client_id,
+        client_secret=secrets.debtor_service_provider.client_secret,
+        access_token_function=get_access_token
+    )
+    debtor_fc = fake_fc()
+
+    res = activate(access_token, debtor_fc, secrets.debtor_service_provider.service_provider_id)
+    assert res.status_code == 201, 'Error activating debtor'
+
+    location = res.headers['Location']
+    activation_id = location.split('/')[-1]
+    assert bool(uuidv4_pattern.fullmatch(activation_id))
+
+    res = get_activation_by_id(access_token, activation_id)
+    assert res.status_code == 200, f'Expected 200 but got {res.status_code}'
+    body = res.json()
+    assert body['id'] == activation_id
+    assert body['payer']['fiscalCode'] == debtor_fc
+    assert body['payer']['rtpSpId'] == secrets.debtor_service_provider.service_provider_id
+
+    try:
+        datetime.strptime(body['effectiveActivationDate'], '%Y-%m-%dT%H:%M:%S.%f')
     except ValueError:
         assert False, 'Invalid date format'
 
@@ -112,3 +147,46 @@ def test_fail_activate_debtor_two_times():
     res = activate(access_token, debtor_fc, secrets.debtor_service_provider.service_provider_id)
     assert res.status_code == 409, f'Error activating debtor, expected 409 but got {res.status_code}'
     assert res.json()['errors'][0]['code'] == '01031000E'
+
+@allure.feature('Activation')
+@allure.story('Get Debtor activation by ID')
+@allure.title('Retrieving non-existent activation returns 404')
+@pytest.mark.auth
+@pytest.mark.activation
+@pytest.mark.unhappy_path
+def test_get_activation_by_id_not_found():
+    access_token = get_valid_access_token(
+        client_id=secrets.debtor_service_provider.client_id,
+        client_secret=secrets.debtor_service_provider.client_secret,
+        access_token_function=get_access_token
+    )
+    random_id = str(uuid.uuid4())
+    res = get_activation_by_id(access_token, random_id)
+    assert res.status_code == 404
+
+@allure.feature('Activation')
+@allure.story('Get Debtor activation by ID')
+@allure.title('Retrieving activation with invalid UUID returns 400')
+@pytest.mark.auth
+@pytest.mark.activation
+@pytest.mark.unhappy_path
+def test_get_activation_by_id_invalid_uuid():
+    access_token = get_valid_access_token(
+        client_id=secrets.debtor_service_provider.client_id,
+        client_secret=secrets.debtor_service_provider.client_secret,
+        access_token_function=get_access_token
+    )
+    invalid_id = 'not-a-valid-uuid'
+    res = get_activation_by_id(access_token, invalid_id)
+    assert res.status_code == 400
+
+@allure.feature('Activation')
+@allure.story('Get Debtor activation by ID')
+@allure.title('Retrieving activation without valid token returns 401')
+@pytest.mark.activation
+@pytest.mark.unhappy_path
+def test_get_activation_by_id_unauthorized():
+    fake_token = 'Bearer invalid.token.value'
+    random_id = str(uuid.uuid4())
+    res = get_activation_by_id(fake_token, random_id)
+    assert res.status_code == 401

--- a/functional-tests/tests/test_debtor_service_provider_availability.py
+++ b/functional-tests/tests/test_debtor_service_provider_availability.py
@@ -1,11 +1,12 @@
 import random
+
 import allure
 import pytest
 
 from api.auth import get_cbi_access_token
 from api.debtor_service_provider import send_srtp_to_cbi
-from api.debtor_service_provider import send_srtp_to_poste
 from api.debtor_service_provider import send_srtp_to_iccrea
+from api.debtor_service_provider import send_srtp_to_poste
 from config.configuration import config
 from config.configuration import secrets
 from utils.cryptography import client_credentials_to_auth_token

--- a/functional-tests/tests/test_debtor_service_provider_availability.py
+++ b/functional-tests/tests/test_debtor_service_provider_availability.py
@@ -52,9 +52,7 @@ def test_send_rtp_to_cbi():
         config.key_path,
     )
     cbi_token = get_cbi_access_token(cert, key, auth)
-
     response = send_srtp_to_cbi(f"Bearer {cbi_token}", cbi_payload)
-
     assert response.status_code == 201
 
 
@@ -179,7 +177,5 @@ def test_send_rtp_to_poste_expired_date():
 def test_send_rtp_to_iccrea():
     rtp_data = generate_rtp_data(payer_id=secrets.iccrea_activated_fiscal_code)
     iccrea_payload = generate_epc_rtp_data(rtp_data, bic='ICRAITRRXXX')
-    print(iccrea_payload)
     response = send_srtp_to_iccrea(iccrea_payload)
-
     assert response.status_code == 201

--- a/functional-tests/tests/test_send_rtp.py
+++ b/functional-tests/tests/test_send_rtp.py
@@ -14,9 +14,9 @@ from utils.dataset import generate_rtp_data
 from utils.dataset import uuidv4_pattern
 
 
-@allure.feature("RTP Send")
-@allure.story("Service provider sends an RTP")
-@allure.title("An RTP is sent through API")
+@allure.feature('RTP Send')
+@allure.story('Service provider sends an RTP')
+@allure.title('An RTP is sent through API')
 @pytest.mark.send
 @pytest.mark.happy_path
 def test_send_rtp_api():
@@ -36,28 +36,28 @@ def test_send_rtp_api():
 
     activation_response = activate(
         debtor_service_provider_access_token,
-        rtp_data["payer"]["payerId"],
+        rtp_data['payer']['payerId'],
         secrets.debtor_service_provider.service_provider_id,
     )
-    assert activation_response.status_code == 201, "Error activating debtor"
+    assert activation_response.status_code == 201, 'Error activating debtor'
 
     send_response = send_rtp(
         access_token=creditor_service_provider_access_token, rtp_payload=rtp_data
     )
     assert send_response.status_code == 201
 
-    location = send_response.headers["Location"]
-    location_split = location.split("/")
+    location = send_response.headers['Location']
+    location_split = location.split('/')
     assert (
-        "/".join(location_split[:-1])
+        '/'.join(location_split[:-1])
         == config.rtp_creation_base_url_path + config.send_rtp_path
     )
     assert bool(uuidv4_pattern.fullmatch(location_split[-1]))
 
 
-@allure.feature("RTP Send")
-@allure.story("Service provider sends an RTP to a provider through Sender")
-@allure.title("An RTP is sent to a CBI service with activated fiscal code")
+@allure.feature('RTP Send')
+@allure.story('Service provider sends an RTP to a provider through Sender')
+@allure.title('An RTP is sent to a CBI service with activated fiscal code')
 @pytest.mark.send
 @pytest.mark.happy_path
 @pytest.mark.real_integration
@@ -79,18 +79,18 @@ def test_send_rtp_to_cbi():
 
     assert send_response.status_code == 201
 
-    location = send_response.headers["Location"]
-    location_split = location.split("/")
+    location = send_response.headers['Location']
+    location_split = location.split('/')
     assert (
-        "/".join(location_split[:-1])
+        '/'.join(location_split[:-1])
         == config.rtp_creation_base_url_path + config.send_rtp_path
     )
     assert bool(uuidv4_pattern.fullmatch(location_split[-1]))
 
 
-@allure.feature("RTP Send")
-@allure.story("Service provider sends an RTP to a provider")
-@allure.title("An RTP is sent to Poste service with activated fiscal code")
+@allure.feature('RTP Send')
+@allure.story('Service provider sends an RTP to a provider')
+@allure.title('An RTP is sent to Poste service with activated fiscal code')
 @pytest.mark.send
 @pytest.mark.happy_path
 @pytest.mark.real_integration
@@ -112,18 +112,18 @@ def test_send_rtp_to_poste():
     )
     assert send_response.status_code == 201
 
-    location = send_response.headers["Location"]
-    location_split = location.split("/")
+    location = send_response.headers['Location']
+    location_split = location.split('/')
     assert (
-        "/".join(location_split[:-1])
+        '/'.join(location_split[:-1])
         == config.rtp_creation_base_url_path + config.send_rtp_path
     )
     assert bool(uuidv4_pattern.fullmatch(location_split[-1]))
 
 
-@allure.feature("RTP Send")
-@allure.story("Service provider sends an RTP to a provider")
-@allure.title("An RTP is sent to ICCREA service with activated fiscal code")
+@allure.feature('RTP Send')
+@allure.story('Service provider sends an RTP to a provider')
+@allure.title('An RTP is sent to ICCREA service with activated fiscal code')
 @pytest.mark.send
 @pytest.mark.happy_path
 @pytest.mark.real_integration
@@ -142,18 +142,18 @@ def test_send_rtp_to_iccrea():
     )
     assert send_response.status_code == 201
 
-    location = send_response.headers["Location"]
-    location_split = location.split("/")
+    location = send_response.headers['Location']
+    location_split = location.split('/')
     assert (
-        "/".join(location_split[:-1])
+        '/'.join(location_split[:-1])
         == config.rtp_creation_base_url_path + config.send_rtp_path
     )
     assert bool(uuidv4_pattern.fullmatch(location_split[-1]))
 
 
-@allure.feature("RTP Send")
-@allure.story("Service provider sends an RTP")
-@allure.title("Debtor fiscal code must be lower case during RTP send")
+@allure.feature('RTP Send')
+@allure.story('Service provider sends an RTP')
+@allure.title('Debtor fiscal code must be lower case during RTP send')
 @pytest.mark.send
 @pytest.mark.unhappy_path
 def test_cannot_send_rtp_api_lower_fiscal_code():
@@ -173,21 +173,21 @@ def test_cannot_send_rtp_api_lower_fiscal_code():
 
     res = activate(
         debtor_service_provider_access_token,
-        rtp_data["payer"]["payerId"],
+        rtp_data['payer']['payerId'],
         secrets.debtor_service_provider.service_provider_id,
     )
-    assert res.status_code == 201, "Error activating debtor"
+    assert res.status_code == 201, 'Error activating debtor'
 
-    rtp_data["payer"]["payerId"] = rtp_data["payer"]["payerId"].lower()
+    rtp_data['payer']['payerId'] = rtp_data['payer']['payerId'].lower()
     response = send_rtp(
         access_token=creditor_service_provider_access_token, rtp_payload=rtp_data
     )
     assert response.status_code == 400
 
 
-@allure.feature("RTP Send")
-@allure.story("Service provider sends an RTP")
-@allure.title("The response body contains a comprehensible error message")
+@allure.feature('RTP Send')
+@allure.story('Service provider sends an RTP')
+@allure.title('The response body contains a comprehensible error message')
 @pytest.mark.send
 @pytest.mark.unhappy_path
 def test_field_error_in_body():
@@ -207,23 +207,23 @@ def test_field_error_in_body():
 
     res = activate(
         debtor_service_provider_access_token,
-        rtp_data["payer"]["payerId"],
+        rtp_data['payer']['payerId'],
         secrets.debtor_service_provider.service_provider_id,
     )
-    assert res.status_code == 201, "Error activating debtor"
+    assert res.status_code == 201, 'Error activating debtor'
 
-    rtp_data["payee"]["payeeId"] = None
+    rtp_data['payee']['payeeId'] = None
     response = send_rtp(
         access_token=creditor_service_provider_access_token, rtp_payload=rtp_data
     )
     assert response.status_code == 400
-    assert response.json()["error"] == "NotNull.createRtpDtoMono.payee.payeeId"
-    assert response.json()["details"] == "payee.payeeId must not be null"
+    assert response.json()['error'] == 'NotNull.createRtpDtoMono.payee.payeeId'
+    assert response.json()['details'] == 'payee.payeeId must not be null'
 
 
-@allure.feature("RTP Send")
-@allure.story("Service provider sends an RTP to a non-activated debtor")
-@allure.title("An RTP is sent through API")
+@allure.feature('RTP Send')
+@allure.story('Service provider sends an RTP to a non-activated debtor')
+@allure.title('An RTP is sent through API')
 @pytest.mark.send
 @pytest.mark.unhappy_path
 def test_cannot_send_rtp_not_activated_user():


### PR DESCRIPTION
### Description

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
- add new test case in `test_activation.py`
- add new endpoint in `activation.py`

<!--- Describe your changes in detail -->

### Motivation and context
new endpoint to retrieve activation from activationID was implemented in `rtp-activator`

<!--- Why is this change required? What problem does it solve? -->
test `happy` and `unhappy` path for the new `endpoint`

### Aggregation level

<!--- Did you write a single reusable test case, or a full test suite?  -->

- [x] Test case
- [ ] Test suite

### Test type

- [x] Functional test
- [ ] Smoke test
- [ ] End to end
- [ ] Performance

### Type of changes

- [ ] Add new test case/suite
- [x] Modify existing test case/suite

### Test Results

- [x] Success
- [ ] Failure
- [ ] Poor performance
- [ ] Good performance

### Did you update secrets accordingly?

- [ ] Yes
  - [ ] `.secrets_template.yaml`
  - [ ] Pipelines' secure file
  - [ ] Confluence
- [x] Not needed
- [ ] No (_please provide further information_)

### Did you update dependencies accordingly?

- [ ] Yes (which requirements.txt did you update?)
<!--- Describe which requirements.txt did you update -->
- [x] Not needed


### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
