### PR TITLE
fix: [SRTP-833]: change status code where debtor is not activated

### DIFF
--- a/bdd-tests/steps/send_rtp_steps.py
+++ b/bdd-tests/steps/send_rtp_steps.py
@@ -35,7 +35,7 @@ def then_the_rtp_is_not_created(context, reason_ko):
         assert context.latest_rtp_response.status_code == 403
 
     if reason_ko == 'THE DEBTOR IS NOT ACTIVATED':
-        assert context.latest_rtp_response.status_code == 422
+        assert context.latest_rtp_response.status_code == 404
 
 
 @given('the Ente Creditore is on the web page')


### PR DESCRIPTION
### Description
Update BDD test during RTP creation to reflect new changes

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
change status code from `422` to `404`
### Motivation and context
When debtor is not activated during RTP creation, status code has been changed in `404`, change needed to be reflected in BDD tests.
<!--- Why is this change required? What problem does it solve? -->

### Aggregation level

<!--- Did you write a single reusable test case, or a full test suite?  -->

- [x] Test case
- [ ] Test suite

### Test type

- [x] Functional test
- [ ] Smoke test
- [ ] End to end
- [ ] Performance

### Type of changes

- [ ] Add new test case/suite
- [x] Modify existing test case/suite

### Test Results

- [x] Success
- [ ] Failure
- [ ] Poor performance
- [ ] Good performance

### Did you update secrets accordingly?

- [ ] Yes
  - [ ] `.secrets_template.yaml`
  - [ ] Pipelines' secure file
  - [ ] Confluence
- [x] Not needed
- [ ] No (_please provide further information_)

### Did you update dependencies accordingly?

- [ ] Yes (which requirements.txt did you update?)
<!--- Describe which requirements.txt did you update -->
- [x] Not needed


### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
