### PR TITLE
feat: [SRTP-1569] add idempotency test

### DIFF
--- a/functional-tests/tests/process_messages_sender/test_RTP_process_sender_IDEMPOTENCY.py
+++ b/functional-tests/tests/process_messages_sender/test_RTP_process_sender_IDEMPOTENCY.py
@@ -1,7 +1,7 @@
 import allure
 import pytest
 
-from api.RTP_get_api import get_rtp
+from api.RTP_get_api import get_rtp_by_notice_number
 from api.RTP_process_sender import send_gpd_message
 from utils.dataset_gpd_message import generate_gpd_message_payload
 
@@ -24,10 +24,10 @@ def test_send_gpd_message_create_idempotency(
 
     Expectations:
     - Both calls return HTTP 200 (idempotent, not an error).
-    - The resourceID in both responses is identical, proving that only one RTP
-      record was created in the database.
-    - The record is retrievable from the DB via the GET endpoint, confirming
-      it was persisted and not just returned from a response cache.
+    - The resourceID in both responses is identical, proving the API returned
+      the cached response and did not process the message twice.
+    - Querying by notice number returns exactly one RTP, confirming that only
+      one record was written to the database.
     """
 
     activate_payer(random_fiscal_code)
@@ -50,17 +50,20 @@ def test_send_gpd_message_create_idempotency(
     assert "resourceID" in body_first, f"Expected 'resourceID' in first response body, got: {response_first.text}"
     assert "resourceID" in body_second, f"Expected 'resourceID' in second response body, got: {response_second.text}"
 
-    resource_id = body_first["resourceID"]
-
-    assert body_second["resourceID"] == resource_id, (
+    assert body_first["resourceID"] == body_second["resourceID"], (
         f"Expected both calls to return the same resourceID (idempotency), "
-        f"but got '{resource_id}' and '{body_second['resourceID']}'"
+        f"but got '{body_first['resourceID']}' and '{body_second['resourceID']}'"
     )
 
-    get_response = get_rtp(access_token=rtp_reader_access_token, rtp_id=resource_id)
-    assert get_response.status_code == 200, (
-        f"Expected RTP '{resource_id}' to exist in DB, got {get_response.status_code}: {get_response.text}"
+    by_notice = get_rtp_by_notice_number(
+        access_token=rtp_reader_access_token,
+        notice_number=message_payload["nav"],
     )
-    assert get_response.json()["resourceID"] == resource_id, (
-        f"DB record resourceID mismatch: expected '{resource_id}', got '{get_response.json().get('resourceID')}'"
+    assert by_notice.status_code == 200, (
+        f"Expected 200 from getByNoticeNumber, got {by_notice.status_code}: {by_notice.text}"
+    )
+
+    results = by_notice.json()
+    assert len(results) == 1, (
+        f"Expected exactly 1 RTP in DB for notice number '{message_payload['nav']}', found {len(results)}"
     )

--- a/functional-tests/tests/process_messages_sender/test_RTP_process_sender_IDEMPOTENCY.py
+++ b/functional-tests/tests/process_messages_sender/test_RTP_process_sender_IDEMPOTENCY.py
@@ -1,0 +1,66 @@
+import allure
+import pytest
+
+from api.RTP_get_api import get_rtp
+from api.RTP_process_sender import send_gpd_message
+from utils.dataset_gpd_message import generate_gpd_message_payload
+
+
+@allure.epic("RTP GPD Message")
+@allure.feature("GPD Message API")
+@allure.story("Idempotency of the sender: same Idempotency-Key produces a single DB record")
+@allure.title("Two CREATE VALID messages with the same Idempotency-Key both succeed but only one RTP is stored")
+@allure.tag("functional", "gpd_message", "rtp_send")
+@pytest.mark.send
+@pytest.mark.happy_path
+def test_send_gpd_message_create_idempotency(
+    rtp_consumer_access_token, rtp_reader_access_token, random_fiscal_code, activate_payer
+):
+    """
+    Send the same CREATE VALID message twice.
+
+    Because send_gpd_message derives the Idempotency-Key deterministically from
+    the message id (msg_id), reusing the same payload reuses the same key.
+
+    Expectations:
+    - Both calls return HTTP 200 (idempotent, not an error).
+    - The resourceID in both responses is identical, proving that only one RTP
+      record was created in the database.
+    - The record is retrievable from the DB via the GET endpoint, confirming
+      it was persisted and not just returned from a response cache.
+    """
+
+    activate_payer(random_fiscal_code)
+
+    message_payload = generate_gpd_message_payload(fiscal_code=random_fiscal_code, operation="CREATE", status="VALID")
+
+    response_first = send_gpd_message(access_token=rtp_consumer_access_token, message_payload=message_payload)
+    assert response_first.status_code == 200, (
+        f"First call: expected 200, got {response_first.status_code}. Response: {response_first.text}"
+    )
+
+    response_second = send_gpd_message(access_token=rtp_consumer_access_token, message_payload=message_payload)
+    assert response_second.status_code == 200, (
+        f"Second call: expected 200, got {response_second.status_code}. Response: {response_second.text}"
+    )
+
+    body_first = response_first.json()
+    body_second = response_second.json()
+
+    assert "resourceID" in body_first, f"Expected 'resourceID' in first response body, got: {response_first.text}"
+    assert "resourceID" in body_second, f"Expected 'resourceID' in second response body, got: {response_second.text}"
+
+    resource_id = body_first["resourceID"]
+
+    assert body_second["resourceID"] == resource_id, (
+        f"Expected both calls to return the same resourceID (idempotency), "
+        f"but got '{resource_id}' and '{body_second['resourceID']}'"
+    )
+
+    get_response = get_rtp(access_token=rtp_reader_access_token, rtp_id=resource_id)
+    assert get_response.status_code == 200, (
+        f"Expected RTP '{resource_id}' to exist in DB, got {get_response.status_code}: {get_response.text}"
+    )
+    assert get_response.json()["resourceID"] == resource_id, (
+        f"DB record resourceID mismatch: expected '{resource_id}', got '{get_response.json().get('resourceID')}'"
+    )


### PR DESCRIPTION
### Description

This PR adds a functional test to verify the idempotency behaviour of the RTP GPD message sender.
When the same message payload (and therefore the same `Idempotency-Key`, derived deterministically from the message's `msg_id`) is submitted twice, the system must return HTTP 200 for both calls and ensure that only a single RTP record is persisted in the database.

### List of changes

- Added `test_RTP_process_sender_IDEMPOTENCY.py` with the test case `test_send_gpd_message_create_idempotency`.

### Motivation and context

Idempotency is a critical correctness property of the GPD message sender: duplicate deliveries (e.g. retries triggered by network issues) must not result in duplicate RTP records in the database. This test provides automated coverage for that guarantee by sending the same `CREATE VALID` message twice and asserting that both calls succeed with the same `resourceID`, then querying by notice number to confirm exactly one record was written to the database.

### Aggregation level

- [x] Test case
- [ ] Test suite

### Test type

- [x] Functional test
- [ ] Bdd test
- [ ] Performance
- [ ] End to end

### Type of changes

- [x] Add new test case/suite
- [ ] Modify existing test case/suite

### Test Results

- [x] Success
- [ ] Failure
- [ ] Poor performance
- [ ] Good performance

### Did you update secrets accordingly?

- [x] Not needed

### Did you update dependencies accordingly?

- [x] Not needed

### Other information

The test flow:
1. Activates the payer for a random fiscal code.
2. Generates a `CREATE VALID` GPD message payload.
3. Sends the payload twice using the same `rtp_consumer_access_token`.
4. Asserts both responses return HTTP 200 and carry the same `resourceID`.
5. Calls `getByNoticeNumber` using the payload's `nav` field and asserts exactly 1 RTP record is returned, confirming no duplicate was written to the database.
