### PR TITLE
feat: [SRTP-1608] manage test cases for process sender API

### DIFF
--- a/functional-tests/tests/process_messages_sender/test_RTP_process_sender_DELETE.py
+++ b/functional-tests/tests/process_messages_sender/test_RTP_process_sender_DELETE.py
@@ -7,8 +7,11 @@ from utils.response_assertions_utils import assert_body_presence, assert_respons
 from utils.test_expectations import (
     DELETE_AFTER_CREATE_CODES,
     DELETE_AFTER_UPDATE_CODES,
+    DELETE_AFTER_UPDATE_STANDALONE_CODES,
+    UPDATE_BEFORE_CREATE_CODES,
     UPDATE_EXPECTED_CODES,
     get_create_expected_code,
+    has_body_for_expected_code,
     should_have_body,
 )
 
@@ -84,3 +87,43 @@ def test_send_gpd_message_delete_after_create_and_update(
 
     expected_delete_code = DELETE_AFTER_UPDATE_CODES[status]
     assert_response_code(response_delete, expected_delete_code, "DELETE after UPDATE", status)
+
+    response_body = get_response_body_safe(response_delete)
+    assert_body_presence(response_body, has_body_for_expected_code(expected_delete_code), "DELETE after UPDATE", status)
+
+
+@allure.epic("RTP GPD Message")
+@allure.feature("GPD Message API")
+@allure.story("Consumer sends DELETE message to Sender after a standalone UPDATE")
+@allure.title("A DELETE message after standalone UPDATE {status}")
+@allure.tag("functional", "gpd_message", "rtp_send", "delete_after_standalone_update_parameterized")
+@pytest.mark.send
+@pytest.mark.parametrize("status", list(DELETE_AFTER_UPDATE_STANDALONE_CODES.keys()))
+def test_send_gpd_message_delete_after_standalone_update(
+    rtp_consumer_access_token, random_fiscal_code, activate_payer, status
+):
+    """Test sending a DELETE operation message via GPD message API after a standalone UPDATE (no prior CREATE)"""
+
+    activate_payer(random_fiscal_code)
+
+    update_payload = generate_gpd_message_payload(fiscal_code=random_fiscal_code, operation="UPDATE", status=status)
+
+    response_update = send_gpd_message(access_token=rtp_consumer_access_token, message_payload=update_payload)
+
+    expected_update_code = UPDATE_BEFORE_CREATE_CODES[status]
+    assert_response_code(response_update, expected_update_code, "UPDATE standalone", status)
+
+    msg_id = update_payload["id"]
+    iuv = update_payload["iuv"]
+
+    delete_payload = generate_gpd_delete_message_payload(msg_id=msg_id, iuv=iuv)
+
+    response_delete = send_gpd_message(access_token=rtp_consumer_access_token, message_payload=delete_payload)
+
+    expected_delete_code = DELETE_AFTER_UPDATE_STANDALONE_CODES[status]
+    assert_response_code(response_delete, expected_delete_code, "DELETE after standalone UPDATE", status)
+
+    response_body = get_response_body_safe(response_delete)
+    assert_body_presence(
+        response_body, has_body_for_expected_code(expected_delete_code), "DELETE after standalone UPDATE", status
+    )

--- a/functional-tests/tests/process_messages_sender/test_RTP_process_sender_UPDATE.py
+++ b/functional-tests/tests/process_messages_sender/test_RTP_process_sender_UPDATE.py
@@ -2,9 +2,13 @@ import allure
 import pytest
 
 from api.RTP_process_sender import send_gpd_message
-from utils.dataset_gpd_message import generate_gpd_message_payload
-from utils.response_assertions_utils import assert_response_code
-from utils.test_expectations import UPDATE_EXPECTED_CODES
+from utils.dataset_gpd_message import generate_gpd_delete_message_payload, generate_gpd_message_payload
+from utils.response_assertions_utils import assert_body_presence, assert_response_code, get_response_body_safe
+from utils.test_expectations import (
+    UPDATE_AFTER_CREATE_AND_DELETE_CODES,
+    UPDATE_EXPECTED_CODES,
+    has_body_for_expected_code,
+)
 
 
 @allure.epic("RTP GPD Message")
@@ -36,6 +40,45 @@ def test_send_gpd_message_update_scenarios(rtp_consumer_access_token, random_fis
 
     expected_code = UPDATE_EXPECTED_CODES[status]
     assert_response_code(response_update, expected_code, "UPDATE", status)
+
+    response_body = get_response_body_safe(response_update)
+    assert_body_presence(response_body, has_body_for_expected_code(expected_code), "UPDATE", status)
+
+
+@allure.epic("RTP GPD Message")
+@allure.feature("GPD Message API")
+@allure.story("Consumer sends RTP message to Sender with different statuses")
+@allure.title("An UPDATE message with status {status} after CREATE VALID and DELETE")
+@allure.tag("functional", "gpd_message", "rtp_send", "update_after_create_and_delete_parameterized")
+@pytest.mark.send
+@pytest.mark.parametrize("status", list(UPDATE_AFTER_CREATE_AND_DELETE_CODES.keys()))
+def test_send_gpd_message_update_after_create_and_delete(
+    rtp_consumer_access_token, random_fiscal_code, activate_payer, status
+):
+    """Test sending an UPDATE after CREATE VALID + DELETE with different statuses"""
+
+    activate_payer(random_fiscal_code)
+
+    create_payload = generate_gpd_message_payload(fiscal_code=random_fiscal_code, operation="CREATE", status="VALID")
+    assert_response_code(
+        send_gpd_message(access_token=rtp_consumer_access_token, message_payload=create_payload), 200, "CREATE", "VALID"
+    )
+
+    iuv = create_payload["iuv"]
+    msg_id = create_payload["id"]
+
+    delete_payload = generate_gpd_delete_message_payload(msg_id=msg_id, iuv=iuv)
+    assert_response_code(
+        send_gpd_message(access_token=rtp_consumer_access_token, message_payload=delete_payload), 200, "DELETE", "VALID"
+    )
+
+    update_payload = generate_gpd_message_payload(
+        fiscal_code=random_fiscal_code, operation="UPDATE", status=status, iuv=iuv, msg_id=msg_id
+    )
+    response_update = send_gpd_message(access_token=rtp_consumer_access_token, message_payload=update_payload)
+
+    expected_code = UPDATE_AFTER_CREATE_AND_DELETE_CODES[status]
+    assert_response_code(response_update, expected_code, "UPDATE after CREATE and DELETE", status)
 
 
 @allure.epic("RTP GPD Message")

--- a/utils/response_assertions_utils.py
+++ b/utils/response_assertions_utils.py
@@ -64,9 +64,8 @@ def assert_response_code(response: Response, expected_code: int, operation: str,
 
 def assert_body_presence(body: Any | None, should_have_body: bool, operation: str, status: str) -> None:
     """
-    Assert that the response body is present or absent as expected.
+    Assert that the response body is present when expected.
+    For error responses (4xx/422) the API always returns a JSON error body, so absence is not asserted.
     """
     if should_have_body:
         assert body is not None, f"Expected non-empty body for {operation} with status {status}, got empty response"
-    else:
-        assert body is None, f"Expected empty body for {operation} with status {status}, got: {body}"

--- a/utils/test_expectations.py
+++ b/utils/test_expectations.py
@@ -3,60 +3,94 @@ Test expectations for GPD message operations.
 Defines expected status codes and body presence for different operations and statuses.
 """
 
+# CREATE
 CREATE_EXPECTED_CODES = {
     "VALID": 200,
     "INVALID": 400,
+    "PARTIALLY_PAID": 400,
     "PAID": 400,
     "PUBLISHED": 400,
     "EXPIRED": 400,
     "DRAFT": 400,
 }
 
+# UPDATE post CREATE VALID
 UPDATE_EXPECTED_CODES = {
     "VALID": 200,
     "INVALID": 200,
     "PAID": 200,
     "EXPIRED": 200,
     "DRAFT": 200,
-    "PARTIALLY_PAID": 422,
-    "PUBLISHED": 422,
+    "PARTIALLY_PAID": 400,
+    "PUBLISHED": 400,
 }
 
+# UPDATE standalone (no prior CREATE)
 UPDATE_BEFORE_CREATE_CODES = {
     "VALID": 200,
+    "INVALID": 404,
+    "PAID": 404,
+    "EXPIRED": 404,
+    "DRAFT": 404,
+    "PARTIALLY_PAID": 400,
+    "PUBLISHED": 400,
+}
+
+# UPDATE post CREATE VALID and DELETE
+UPDATE_AFTER_CREATE_AND_DELETE_CODES = {
+    "VALID": 422,
     "INVALID": 422,
     "PAID": 422,
     "EXPIRED": 422,
     "DRAFT": 422,
-    "PARTIALLY_PAID": 422,
-    "PUBLISHED": 422,
+    "PARTIALLY_PAID": 400,
+    "PUBLISHED": 400,
 }
 
+# DELETE post CREATE (status refers to the CREATE status)
 DELETE_AFTER_CREATE_CODES = {
     "VALID": 200,
+    "INVALID": 404,
+    "PARTIALLY_PAID": 404,
+    "PAID": 404,
+    "PUBLISHED": 404,
+    "EXPIRED": 404,
+    "DRAFT": 404,
+}
+
+# DELETE post CREATE VALID and UPDATE (status refers to the UPDATE status)
+DELETE_AFTER_UPDATE_CODES = {
+    "VALID": 200,
+    "PARTIALLY_PAID": 200,
+    "PUBLISHED": 200,
     "INVALID": 422,
     "PAID": 422,
-    "PUBLISHED": 422,
     "EXPIRED": 422,
     "DRAFT": 422,
 }
 
-DELETE_AFTER_UPDATE_CODES = {
+# DELETE post standalone UPDATE (status refers to the UPDATE status)
+DELETE_AFTER_UPDATE_STANDALONE_CODES = {
     "VALID": 200,
-    "INVALID": 422,
-    "PAID": 422,
-    "EXPIRED": 422,
-    "DRAFT": 422,
-    "PARTIALLY_PAID": 422,
-    "PUBLISHED": 422,
+    "INVALID": 404,
+    "PARTIALLY_PAID": 404,
+    "PAID": 404,
+    "PUBLISHED": 404,
+    "EXPIRED": 404,
+    "DRAFT": 404,
 }
 
 STATUSES_WITH_BODY = {"VALID"}
 
 
 def should_have_body(status: str) -> bool:
-    """Check if a status should return a non-empty body"""
+    """Check if a status should return a non-empty body (for CREATE and simple DELETE scenarios)"""
     return status in STATUSES_WITH_BODY
+
+
+def has_body_for_expected_code(expected_code: int) -> bool:
+    """Return True if a 200 response is expected (i.e. a body should be present)"""
+    return expected_code == 200
 
 
 def get_create_expected_code(status: str) -> int:


### PR DESCRIPTION
### Description        

  This PR updates the functional test suite for the `rtp-process-sender` (GPD message API) to reflect the new expected HTTP responses introduced by the latest backend changes.  
  All CREATE, UPDATE, and DELETE operation scenarios have been revised, two new test scenarios have been added, and a test infrastructure bug discovered during the run has been
  fixed.                                                                                                                                                                         
                                                                         
  ### List of changes                    

  - **`utils/test_expectations.py`**
    - `CREATE_EXPECTED_CODES`: added `PARTIALLY_PAID → 400`
    - `UPDATE_EXPECTED_CODES` (post CREATE VALID): changed `PARTIALLY_PAID` and `PUBLISHED` from `422 → 400`                                                                     
    - `UPDATE_BEFORE_CREATE_CODES` (standalone UPDATE): changed `INVALID`, `PAID`, `EXPIRED`, `DRAFT` from `422 → 404`; changed `PARTIALLY_PAID` and `PUBLISHED` from `422 → 400`
    - `DELETE_AFTER_CREATE_CODES`: added `PARTIALLY_PAID → 404`; changed all non-VALID statuses from `422 → 404`                                                                 
    - `DELETE_AFTER_UPDATE_CODES` (post CREATE VALID + UPDATE): changed `PARTIALLY_PAID` and `PUBLISHED` from `422 → 200`                                                        
    - Added `UPDATE_AFTER_CREATE_AND_DELETE_CODES`: new dictionary for UPDATE after CREATE VALID + DELETE scenario                                                               
    - Added `DELETE_AFTER_UPDATE_STANDALONE_CODES`: new dictionary for DELETE after standalone UPDATE scenario                                                                   
    - Added `has_body_for_expected_code(expected_code)` helper: returns `True` when expected code is `200`                                                                       
                                                                                                                                                                                 
  - **`functional-tests/tests/process_messages_sender/test_RTP_process_sender_UPDATE.py`**                                                                                       
    - `test_send_gpd_message_update_scenarios`: added body assertion using `has_body_for_expected_code`                                                                          
    - Added `test_send_gpd_message_update_after_create_and_delete`: new parameterized test covering UPDATE after CREATE VALID + DELETE for all statuses                          
                                                                                                                                                                                 
  - **`functional-tests/tests/process_messages_sender/test_RTP_process_sender_DELETE.py`**                                                                                       
    - `test_send_gpd_message_delete_after_create_and_update`: added body assertion using `has_body_for_expected_code`                                                            
    - Added `test_send_gpd_message_delete_after_standalone_update`: new parameterized test covering DELETE after a standalone UPDATE (no prior CREATE) for all statuses          
                                                                                                                                                                                 
  - **`utils/response_assertions_utils.py`**                                                                                                                                     
    - `assert_body_presence`: removed the body-absence assertion (`assert body is None`) for non-200 responses — the API always returns a JSON error body (e.g. `{"code": "...", 
  "description": "..."}`) for 4xx/422 responses, making the previous assertion incorrect                                                                                         
                                                                         
  ### Motivation and context                                                                                                                                                     
                                                                         
  The backend introduced changes to the GPD message processing logic that altered the expected HTTP response codes for several operation/status combinations. The test suite     
  needed to be updated to reflect these new contracts. Additionally, two scenarios that were previously untested have been added: UPDATE after a DELETE (to verify state machine 
  rejection of transitions on a cancelled RTP) and DELETE after a standalone UPDATE (to verify lookup behaviour when no CREATE was ever sent).                                   
                                                                         
  A secondary issue was discovered: the test infrastructure was asserting that error responses have an empty body (`body is None`). The API consistently returns a structured    
  JSON error body for all non-200 responses, which caused 24 false failures. This has been corrected.
                                                                                                                                                                                 
  ### Aggregation level                                                  
                                         
  - [ ] Test case                                                                                                                                                                
  - [x] Test suite
                                                                                                                                                                                 
  ### Test type                                                          
                                         
  - [x] Functional test
  - [ ] Bdd test
  - [ ] Performance
  - [ ] End to end
  - [ ] Performance                                                                                                                                                              
   
  ### Type of changes                                                                                                                                                            
                                                                         
  - [x] Add new test case/suite          
  - [x] Modify existing test case/suite

  ### Test Results

  - [x] Success
  - [ ] Failure
  - [ ] Poor performance                                                                                                                                                         
  - [ ] Good performance
                                                                                                                                                                                 
  > 53 passed / 53 total in 68s                                                                                                                                                  
                                         
  ### Did you update secrets accordingly?                                                                                                                                        
                                                                         
  - [x] Not needed                       

  ### Did you update dependencies accordingly?                                                                                                                                   
   
  - [x] Not needed                                                                                                                                                               
                                                                         
  ### Other information                  

  Summary of expected HTTP responses validated by the suite:                                                                                                                     
   
  | Operation | Status | HTTP |                                                                                                                                                  
  |---|---|---|                                                          
  | CREATE | VALID | 200 |               
  | CREATE | INVALID / PARTIALLY_PAID / PAID / PUBLISHED / EXPIRED / DRAFT | 400 |
  | UPDATE (post CREATE VALID) | VALID / INVALID / PAID / EXPIRED / DRAFT | 200 |                                                                                                
  | UPDATE (post CREATE VALID) | PARTIALLY_PAID / PUBLISHED | 400 |
  | UPDATE (standalone) | VALID | 200 |                                                                                                                                          
  | UPDATE (standalone) | INVALID / PAID / EXPIRED / DRAFT | 404 |                                                                                                               
  | UPDATE (standalone) | PARTIALLY_PAID / PUBLISHED | 400 |
  | UPDATE (post CREATE VALID + DELETE) | VALID / INVALID / PAID / EXPIRED / DRAFT | 422 |                                                                                       
  | UPDATE (post CREATE VALID + DELETE) | PARTIALLY_PAID / PUBLISHED | 400 |
  | DELETE (post CREATE VALID) | VALID | 200 |                                                                                                                                   
  | DELETE (post CREATE VALID) | INVALID / PARTIALLY_PAID / PAID / PUBLISHED / EXPIRED / DRAFT | 404 |
  | DELETE (post CREATE VALID + UPDATE) | VALID / PARTIALLY_PAID / PUBLISHED | 200 |                                                                                             
  | DELETE (post CREATE VALID + UPDATE) | INVALID / PAID / EXPIRED / DRAFT | 422 |
  | DELETE (post standalone UPDATE) | VALID | 200 |                                                                                                                              
  | DELETE (post standalone UPDATE) | INVALID / PARTIALLY_PAID / PAID / PUBLISHED / EXPIRED / DRAFT | 404 |