### PR TITLE
fix: [SRTP-1753] Fix payees consents tests

### DIFF
--- a/api/service_registry_payee_registry_api.py
+++ b/api/service_registry_payee_registry_api.py
@@ -5,7 +5,7 @@ import requests
 from api.utils.api_version import PAYEES_VERSION
 from api.utils.endpoints import PAYEES_CONSENTS_URL, PAYEES_URL
 from api.utils.http_utils import HTTP_TIMEOUT
-from utils.datetime_utils import get_date_or_today
+from utils.datetime_utils import get_date_or_default_today
 
 CONSENTS_DEFAULT_PAGE_SIZE = 20
 CONSENTS_DEFAULT_PAGE_NUMBER = 0
@@ -35,7 +35,7 @@ def get_payees_consents(
         params["consent"] = consent
     if from_date is not None:
         params["fromDate"] = from_date
-    params["toDate"] = get_date_or_today(to_date)
+    params["toDate"] = get_date_or_default_today(to_date)
 
     return requests.get(
         url=PAYEES_CONSENTS_URL,

--- a/api/service_registry_payee_registry_api.py
+++ b/api/service_registry_payee_registry_api.py
@@ -27,7 +27,7 @@ def get_payees_consents(
     access_token: str,
     page_number: int = CONSENTS_DEFAULT_PAGE_NUMBER,
     page_size: int = CONSENTS_DEFAULT_PAGE_SIZE,
-    consent: str = CONSENTS_DEFAULT_VALUE,
+    consent: str | None = CONSENTS_DEFAULT_VALUE,
     from_date: str | None = None,
     to_date: str | None = None,
 ) -> requests.Response:

--- a/api/service_registry_payee_registry_api.py
+++ b/api/service_registry_payee_registry_api.py
@@ -1,3 +1,4 @@
+import datetime
 import uuid
 
 import requests
@@ -5,6 +6,10 @@ import requests
 from api.utils.api_version import PAYEES_VERSION
 from api.utils.endpoints import PAYEES_CONSENTS_URL, PAYEES_URL
 from api.utils.http_utils import HTTP_TIMEOUT
+
+CONSENTS_DEFAULT_PAGE_SIZE = 20
+CONSENTS_DEFAULT_PAGE_NUMBER = 0
+CONSENTS_DEFAULT_VALUE = "OPT_OUT"
 
 
 def get_payee_registry(access_token: str, page: int = 0, size: int = 20):
@@ -19,9 +24,9 @@ def get_payee_registry(access_token: str, page: int = 0, size: int = 20):
 
 def get_payees_consents(
     access_token: str,
-    page_number: int = 0,
-    page_size: int = 20,
-    consent: str | None = None,
+    page_number: int = CONSENTS_DEFAULT_PAGE_NUMBER,
+    page_size: int = CONSENTS_DEFAULT_PAGE_SIZE,
+    consent: str = CONSENTS_DEFAULT_VALUE,
     from_date: str | None = None,
     to_date: str | None = None,
 ) -> requests.Response:
@@ -30,8 +35,7 @@ def get_payees_consents(
         params["consent"] = consent
     if from_date is not None:
         params["fromDate"] = from_date
-    if to_date is not None:
-        params["toDate"] = to_date
+    params["toDate"] = get_date_or_today(to_date)
 
     return requests.get(
         url=PAYEES_CONSENTS_URL,

--- a/api/service_registry_payee_registry_api.py
+++ b/api/service_registry_payee_registry_api.py
@@ -5,7 +5,6 @@ import requests
 from api.utils.api_version import PAYEES_VERSION
 from api.utils.endpoints import PAYEES_CONSENTS_URL, PAYEES_URL
 from api.utils.http_utils import HTTP_TIMEOUT
-
 from utils.datetime_utils import get_date_or_today
 
 CONSENTS_DEFAULT_PAGE_SIZE = 20

--- a/api/service_registry_payee_registry_api.py
+++ b/api/service_registry_payee_registry_api.py
@@ -1,4 +1,3 @@
-import datetime
 import uuid
 
 import requests

--- a/api/service_registry_payee_registry_api.py
+++ b/api/service_registry_payee_registry_api.py
@@ -7,6 +7,8 @@ from api.utils.api_version import PAYEES_VERSION
 from api.utils.endpoints import PAYEES_CONSENTS_URL, PAYEES_URL
 from api.utils.http_utils import HTTP_TIMEOUT
 
+from utils.datetime_utils import get_date_or_today
+
 CONSENTS_DEFAULT_PAGE_SIZE = 20
 CONSENTS_DEFAULT_PAGE_NUMBER = 0
 CONSENTS_DEFAULT_VALUE = "OPT_OUT"

--- a/functional-tests/tests/service_registry/test_get_payees_consents.py
+++ b/functional-tests/tests/service_registry/test_get_payees_consents.py
@@ -3,7 +3,6 @@ import pytest
 
 from api.service_registry_payee_registry_api import get_payees_consents
 from utils.datetime_utils import get_yesterday_and_today
-from utils.datetime_utils import get_date_or_today
 
 DEFAULT_PAGE_NUMBER = 0
 DEFAULT_PAGE_SIZE = 20

--- a/functional-tests/tests/service_registry/test_get_payees_consents.py
+++ b/functional-tests/tests/service_registry/test_get_payees_consents.py
@@ -3,6 +3,7 @@ import pytest
 
 from api.service_registry_payee_registry_api import get_payees_consents
 from utils.datetime_utils import get_yesterday_and_today
+from utils.datetime_utils import get_date_or_today
 
 DEFAULT_PAGE_NUMBER = 0
 DEFAULT_PAGE_SIZE = 20
@@ -46,7 +47,16 @@ def test_get_payees_consents_returns_200(pagopa_payees_registry_consent_token: s
 @pytest.mark.unhappy_path
 @pytest.mark.get
 def test_get_payees_consents_invalid_auth() -> None:
-    response = get_payees_consents(access_token="invalid_token")
+    yesterday, today = get_yesterday_and_today()
+
+    response = get_payees_consents(
+        access_token="invalid_token",
+        page_number=DEFAULT_PAGE_NUMBER,
+        page_size=DEFAULT_PAGE_SIZE,
+        consent=CONSENT_OPT_OUT,
+        from_date=yesterday,
+        to_date=today,
+    )
 
     assert response.status_code == 401, f"Expected 401, got {response.status_code}: {response.text}"
 

--- a/utils/datetime_utils.py
+++ b/utils/datetime_utils.py
@@ -17,7 +17,7 @@ def get_date_or_today(date_str: str | None) -> str:
     """
     if date_str is not None:
         return date_str
-    return datetime.datetime.now().strftime("%Y-%m-%d")
+    return datetime.now().strftime("%Y-%m-%d")
 
 
 def generate_expiry_date(min_days: int = 1, max_days: int = 365) -> str:

--- a/utils/datetime_utils.py
+++ b/utils/datetime_utils.py
@@ -7,8 +7,7 @@ def get_yesterday_and_today() -> tuple[str, str]:
     return (now - timedelta(days=1)).strftime("%Y-%m-%d"), now.strftime("%Y-%m-%d")
 
 
-# Returns today's date when to_date is None (API requires toDate in every request).
-def get_date_or_today(date_str: str | None) -> str:
+def get_date_or_default_today(date_str: str | None) -> str:
     """
     Get the provided date string or return today's date if the string is None.
     Args:
@@ -16,9 +15,22 @@ def get_date_or_today(date_str: str | None) -> str:
     Returns:
         A date string in YYYY-MM-DD format
     """
+    today = datetime.now().strftime("%Y-%m-%d")
+    return get_date_or_default(date_str, today)
+
+
+def get_date_or_default(date_str: str | None, default_date: str ) -> str:
+    """
+    Get the provided date string or return the default date if the string is None.
+    Args:
+        date_str: A date string in YYYY-MM-DD format or None
+        default: A default date string in YYYY-MM-DD format
+    Returns:
+        A date string in YYYY-MM-DD format
+    """
     if date_str is not None:
         return date_str
-    return datetime.now().strftime("%Y-%m-%d")
+    return default_date
 
 
 def generate_expiry_date(min_days: int = 1, max_days: int = 365) -> str:

--- a/utils/datetime_utils.py
+++ b/utils/datetime_utils.py
@@ -6,7 +6,7 @@ def get_yesterday_and_today() -> tuple[str, str]:
     now = datetime.now()
     return (now - timedelta(days=1)).strftime("%Y-%m-%d"), now.strftime("%Y-%m-%d")
 
-"""This method is required as the API requires a toDate parameter, but it should default to today's date if not provided."""
+# Returns today's date when to_date is None (API requires toDate in every request).
 def get_date_or_today(date_str: str | None) -> str:
     """
     Get the provided date string or return today's date if the string is None.

--- a/utils/datetime_utils.py
+++ b/utils/datetime_utils.py
@@ -6,6 +6,7 @@ def get_yesterday_and_today() -> tuple[str, str]:
     now = datetime.now()
     return (now - timedelta(days=1)).strftime("%Y-%m-%d"), now.strftime("%Y-%m-%d")
 
+
 # Returns today's date when to_date is None (API requires toDate in every request).
 def get_date_or_today(date_str: str | None) -> str:
     """

--- a/utils/datetime_utils.py
+++ b/utils/datetime_utils.py
@@ -6,6 +6,19 @@ def get_yesterday_and_today() -> tuple[str, str]:
     now = datetime.now()
     return (now - timedelta(days=1)).strftime("%Y-%m-%d"), now.strftime("%Y-%m-%d")
 
+"""This method is required as the API requires a toDate parameter, but it should default to today's date if not provided."""
+def get_date_or_today(date_str: str | None) -> str:
+    """
+    Get the provided date string or return today's date if the string is None.
+    Args:
+        date_str: A date string in YYYY-MM-DD format or None
+    Returns:
+        A date string in YYYY-MM-DD format
+    """
+    if date_str is not None:
+        return date_str
+    return datetime.datetime.now().strftime("%Y-%m-%d")
+
 
 def generate_expiry_date(min_days: int = 1, max_days: int = 365) -> str:
     """Generate a random expiry date in the future.


### PR DESCRIPTION
### Description

Fixes the payees consents tests by ensuring required request parameters (`toDate`, `consent`) are always sent to the API. The API backend apparently requires `toDate` and `consent` in every request; previously they were optional and omitted by default, causing test failures.

### List of changes

- `api/service_registry_payee_registry_api.py`: Added module-level constants for default pagination/consent values. Changed `consent` default from `None` to `"OPT_OUT"`. Made `toDate` always sent (defaults to today via `get_date_or_today`).
- `utils/datetime_utils.py`: Added `get_date_or_today(date_str)` utility — returns the given date or today if `None`.
- `functional-tests/tests/service_registry/test_get_payees_consents.py`: Expanded `test_get_payees_consents_invalid_auth` to pass all required params explicitly.

### Motivation and context

API requires `toDate` and `consent` parameters; tests were omitting them by relying on `None` defaults, causing unexpected responses.

### Aggregation level

- [ ] Test case
- [x] Test suite

### Test type

- [x] Functional test
- [ ] Bdd test
- [ ] Performance
- [ ] End to end

### Type of changes

- [ ] Add new test case/suite
- [x] Modify existing test case/suite

### Test Results

- [ ] Success
- [ ] Failure
- [ ] Poor performance
- [ ] Good performance

### Did you update secrets accordingly?

- [ ] Yes
- [x] Not needed
- [ ] No

### Did you update dependencies accordingly?

- [ ] Yes
- [x] Not needed