### PR TITLE
feat: [SRTP-1815] Add test case for Send RTP callback triggering Invalid Status

### DIFF
--- a/functional-tests/tests/callbacks/test_RTP_callback_DS_05.py
+++ b/functional-tests/tests/callbacks/test_RTP_callback_DS_05.py
@@ -10,6 +10,7 @@ from utils.dataset_callback_data_DS_05_ACTC_compliant import (
     generate_invalid_callback_data_DS_05_ACTC,
 )
 from utils.dataset_RTP_data import generate_rtp_data
+from utils.http_utils import extract_id_from_location
 
 
 @allure.epic("RTP Callback")
@@ -38,7 +39,8 @@ def test_receive_rtp_callback_DS_05_ACTC_compliant(
     assert send_response.status_code == 201
 
     location = send_response.headers["Location"]
-    resource_id = location.split("/")[-1]
+    resource_id = extract_id_from_location(location)
+    assert resource_id, f"Could not extract resource ID from Location header: {location}"
     original_msg_id = resource_id.replace("-", "")
 
     callback_data = build_callback_with_original_msg_id(
@@ -95,7 +97,8 @@ def test_receive_rtp_callback_DS_05_ACTC_non_compliant(
     assert send_response.status_code == 201
 
     location = send_response.headers["Location"]
-    resource_id = location.split("/")[-1]
+    resource_id = extract_id_from_location(location)
+    assert resource_id, f"Could not extract resource ID from Location header: {location}"
     original_msg_id = resource_id.replace("-", "")
 
     get_response_pre_callback = get_rtp(
@@ -158,7 +161,8 @@ def test_fail_send_rtp_callback_invalid_transition_DS_05_ACTC_compliant(
     assert send_response.status_code == 201
 
     location = send_response.headers["Location"]
-    resource_id = location.split("/")[-1]
+    resource_id = extract_id_from_location(location)
+    assert resource_id, f"Could not extract resource ID from Location header: {location}"
     original_msg_id = resource_id.replace("-", "")
 
     callback_data = build_callback_with_original_msg_id(

--- a/functional-tests/tests/callbacks/test_RTP_callback_DS_05.py
+++ b/functional-tests/tests/callbacks/test_RTP_callback_DS_05.py
@@ -130,3 +130,75 @@ def test_receive_rtp_callback_DS_05_ACTC_non_compliant(
     assert get_response.status_code == 200
     body = get_response.json()
     assert body["status"] == "SENT", f"Expected RTP status SENT after non-compliant callback, got {body['status']}"
+
+
+@allure.epic("RTP Callback")
+@allure.feature("RTP Callback DS_05")
+@allure.story("Service provider sends a callback referred to an RTP with status ACTC")
+@allure.title("Failed callback for invalid RTP transition - DS-05 ACTC compliant")
+@allure.tag("functional", "unhappy_path", "rtp_callback", "ds_05_actc_compliant")
+@pytest.mark.callback
+@pytest.mark.unhappy_path
+def test_fail_send_rtp_callback_invalid_transition_DS_05_ACTC_compliant(
+    creditor_service_provider_token_a,
+    rtp_reader_access_token,
+    activate_payer,
+    debtor_sp_mock_cert_key,
+):
+
+    rtp_data = generate_rtp_data()
+
+    activation_response = activate_payer(rtp_data["payer"]["payerId"])
+    assert activation_response.status_code == 201
+
+    send_response = send_rtp(
+        access_token=creditor_service_provider_token_a,
+        rtp_payload=rtp_data,
+    )
+    assert send_response.status_code == 201
+
+    location = send_response.headers["Location"]
+    resource_id = location.split("/")[-1]
+    original_msg_id = resource_id.replace("-", "")
+
+    callback_data = build_callback_with_original_msg_id(
+        generate_callback_data_DS_05_ACTC_compliant,
+        original_msg_id,
+        is_document=True,
+    )
+
+    cert, key = debtor_sp_mock_cert_key
+
+    first_callback_response = srtp_callback(
+        rtp_payload=callback_data,
+        cert_path=cert,
+        key_path=key,
+    )
+    assert first_callback_response.status_code == 200, (
+        f"Error from first callback, expected 200 got {first_callback_response.status_code}"
+    )
+
+    first_get_response = get_rtp(
+        access_token=rtp_reader_access_token,
+        rtp_id=resource_id,
+    )
+    assert first_get_response.status_code == 200
+    body = first_get_response.json()
+    assert body["status"] == "ACCEPTED"
+
+    second_callback_response = srtp_callback(
+        rtp_payload=callback_data,
+        cert_path=cert,
+        key_path=key,
+    )
+    assert second_callback_response.status_code == 400, (
+        f"Error from second callback, expected 400 got {second_callback_response.status_code}"
+    )
+
+    second_get_response = get_rtp(
+        access_token=rtp_reader_access_token,
+        rtp_id=resource_id,
+    )
+    assert second_get_response.status_code == 200
+    body = second_get_response.json()
+    assert body["status"] == "ACCEPTED"

--- a/utils/cryptography_utils.py
+++ b/utils/cryptography_utils.py
@@ -45,7 +45,7 @@ def pfx_to_pem(base64_pfx, base64_password, cert_destination_path=None, key_dest
     """
 
     pfx_data = base64.b64decode(base64_pfx)
-    pfx_password = base64.b64decode(base64_password)
+    pfx_password = base64.b64decode(base64_password) if base64_password else None
 
     private_key, certificate, _ = load_key_and_certificates(pfx_data, pfx_password)
 


### PR DESCRIPTION
### Description

This PR introduces a new functional test that validates callback state-transition behavior for DS_05 ACTC and includes a small robustness fix in certificate conversion logic when a PFX password is not provided.

### List of changes

- Added a new test in test_RTP_callback_DS_05.py to verify an invalid transition scenario:
  - First compliant DS_05 ACTC callback returns 200 and sets RTP status to ACCEPTED.
  - A second identical callback on the same RTP returns 400 (Bad Request).
  - RTP status remains ACCEPTED after the rejected second callback.
- Updated cryptography_utils.py in function pfx_to_pem:
  - Changed password decoding to handle missing/empty password safely by using None when base64_password is not provided.

### Motivation and context

- The new test covers an important negative path: duplicate callback transition after acceptance must be rejected while preserving the already reached valid status.
- The cryptography utility change prevents decoding attempts when no password is available, improving resilience of PFX handling logic in that case.

### Aggregation level

- [x] Test case
- [ ] Test suite

### Test type

- [x] Functional test
- [ ] Bdd test
- [ ] Performance
- [ ] End to end
- [ ] Performance

### Type of changes

- [x] Add new test case/suite
- [ ] Modify existing test case/suite

### Test Results

- [x] Success
- [ ] Failure
- [ ] Poor performance
- [ ] Good performance

### Did you update secrets accordingly?

- [ ] Yes
  - [ ] .secrets_template.yaml
  - [ ] Pipelines' secure file
  - [ ] Confluence
- [x] Not needed
- [ ] No (please provide further information)

### Did you update dependencies accordingly?

- [ ] Yes (which requirements.txt did you update?)
- [x] Not needed

### Other information

No UI/screenshots are applicable for this change set.