### PR TITLE
feat: [SRTP-1822] Improve script to make it able to run continously

### DIFF
--- a/load-tests/README.md
+++ b/load-tests/README.md
@@ -93,7 +93,7 @@ If `MINUTES` is omitted or set to `0`, the script behaves like a single run.
 T_batch ≈ (ROWS / RATE) × T_rec
 msgs/s  = ROWS / T_batch = RATE / T_rec
 ```
-Where `T_rec` is the server-side processing time per record (~0.085s measured in UAT). Example: `RATE=1` → ~11 msg/s; `RATE=5` → ~59 msg/s.
+Where `T_rec` is the server-side processing time per record.
 
 ### 3. Delete an RTP
 ```bash

--- a/load-tests/README.md
+++ b/load-tests/README.md
@@ -33,9 +33,67 @@ python gpd-massive/upload_create_pd_file.py
 ```
 
 ### 2. Create and send a json (CREATE and UPDATE)
+
+All parameters are passed as environment variables.
+
+**Single run — CREATE:**
 ```bash
-python gpd-massive/send_to_gpd_queue.py
+ROWS=100 \
+OUT_DIR=./output \
+OPERATION=CREATE \
+STATUS=VALID \
+FISCAL_CODE=<DEBTOR_FISCAL_CODE> \
+BULK=false \
+RATE=10 \
+python3 send_to_gpd_queue.py
 ```
+
+**Single run — UPDATE** (requires a prior CREATE run in the same `OUT_DIR`):
+```bash
+ROWS=100 \
+OUT_DIR=./output \
+OPERATION=UPDATE \
+STATUS=PAID \
+FISCAL_CODE=<DEBTOR_FISCAL_CODE> \
+BULK=false \
+RATE=10 \
+python3 send_to_gpd_queue.py
+```
+
+**Continuous run** — loops until the `MINUTES` deadline, re-sending batches on each iteration. Errors on individual iterations are caught and logged so the loop continues:
+```bash
+ROWS=50 \
+OUT_DIR=./output \
+OPERATION=CREATE \
+STATUS=VALID \
+FISCAL_CODE=<DEBTOR_FISCAL_CODE> \
+BULK=false \
+RATE=1 \
+MINUTES=30 \
+python3 send_to_gpd_queue.py
+```
+
+If `MINUTES` is omitted or set to `0`, the script behaves like a single run.
+
+| Variable | Required | Description |
+|---|---|---|
+| `ROWS` | yes | Number of records per batch |
+| `OUT_DIR` | yes | Directory for generated NDJSON files |
+| `OPERATION` | yes | `CREATE` or `UPDATE` |
+| `STATUS` | yes | Record status (e.g. `VALID`, `PAID`) |
+| `FISCAL_CODE` | yes | Debtor fiscal code applied to all records |
+| `BULK` | yes | `true`/`false` — bulk mode on the API |
+| `RATE` | yes | Server-side concurrency (parallel workers) |
+| `MINUTES` | no | Duration in minutes for continuous mode (default: `0`) |
+| `PSP_CODE` | no | PSP code |
+| `PSP_TAX_CODE` | no | PSP tax code |
+
+**Throughput estimation:**
+```
+T_batch ≈ (ROWS / RATE) × T_rec
+msgs/s  = ROWS / T_batch = RATE / T_rec
+```
+Where `T_rec` is the server-side processing time per record (~0.085s measured in UAT). Example: `RATE=1` → ~11 msg/s; `RATE=5` → ~59 msg/s.
 
 ### 3. Delete an RTP
 ```bash

--- a/load-tests/send_to_gpd_queue.py
+++ b/load-tests/send_to_gpd_queue.py
@@ -156,7 +156,6 @@ def run_continuously(timelength_minutes: float, block: Callable[[], None]):
         timelength_minutes (float): The duration in minutes for which to run the block of code continuously.
         block (callable[[], None]): The block of code to execute, which takes no arguments and returns None.
     """
-    # If the specified duration is very short, run the block once without entering the loop
     if timelength_minutes < 0:
         raise ValueError("timelength_minutes must be non-negative")
     if timelength_minutes < 0.01:
@@ -168,13 +167,13 @@ def run_continuously(timelength_minutes: float, block: Callable[[], None]):
             block()
         except Exception as e:
             print(f"Error during operation: {e}")
-            continue  # Continue to next iteration until deadline
+            continue  
 
 def main() -> None:
     rows = int(require_env("ROWS"))
     out_dir = Path(require_env("OUT_DIR"))
     out_dir.mkdir(parents=True, exist_ok=True)
-    mins = float(int( require_env_or_default("MINUTES", "0") ))
+    mins = float(require_env_or_default("MINUTES", "0"))
     op_env = require_env("OPERATION").upper()
     if op_env not in {"CREATE", "UPDATE"}:
         raise SystemExit("OPERATION must be CREATE or UPDATE")

--- a/load-tests/send_to_gpd_queue.py
+++ b/load-tests/send_to_gpd_queue.py
@@ -4,10 +4,10 @@ import os
 from collections.abc import Iterable, Iterator
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-
+from datetime import datetime, timedelta
 import requests
 from dotenv import load_dotenv
-from utilities import random_iuv, require_env, to_epoch_millis
+from utilities import random_iuv, require_env, require_env_or_default, to_epoch_millis
 
 from config import GPD_TEST_BASE_URL
 
@@ -26,13 +26,12 @@ def generate_create_records(count: int) -> Iterable[dict]:
     debtor_cf = require_env("FISCAL_CODE")
 
     for i in range(count):
-        ts = to_epoch_millis(now + timedelta(seconds=i))
         due = to_epoch_millis(now + timedelta(days=30, seconds=i))
         iuv = random_iuv(17)
         yield {
             "id": random_iuv(10),
             "operation": operation,
-            "timestamp": ts,
+            "timestamp": to_epoch_millis(datetime.now(UTC)),
             "iuv": iuv,
             "subject": "Performance Test RTP",
             "description": "Test RTP from queue API",
@@ -142,7 +141,7 @@ def send_file_to_api(path: Path) -> dict:
 
     with path.open("rb") as fh:
         files = {"file": (path.name, fh, "application/x-ndjson")}
-        resp = requests.post(api_url, params=params, files=files, timeout=300)
+        resp = requests.post(api_url, params=params, files=files, timeout=30000)
     try:
         resp.raise_for_status()
     except requests.HTTPError:
@@ -150,24 +149,46 @@ def send_file_to_api(path: Path) -> dict:
     return resp.json()
 
 
+def run_continuously(timelength_minutes: float, block: callable[[], None]):
+    """Utility function to run a block of code continuously for a specified duration in minutes.
+    If the duration is less than 0.01 minutes (i.e., less than 0.6 seconds), the block will be executed only once.
+    Args:
+        timelength_minutes (float): The duration in minutes for which to run the block of code continuously.
+        block (callable[[], None]): The block of code to execute, which takes no arguments and returns None.
+    """
+    # If the specified duration is very short, run the block once without entering the loop
+    if abs(timelength_minutes) < 0.01:
+        block()
+        return
+    deadline = datetime.now() + timedelta(minutes=timelength_minutes)
+    while datetime.now() < deadline:
+        try:
+            block()
+        except Exception as e:
+            print(f"Error during operation: {e}")
+            continue  # Continue to next iteration until deadline
+
 def main() -> None:
     rows = int(require_env("ROWS"))
     out_dir = Path(require_env("OUT_DIR"))
     out_dir.mkdir(parents=True, exist_ok=True)
-
+    mins = float(int( require_env_or_default("MINUTES", "0") ))
     op_env = require_env("OPERATION").upper()
     if op_env not in {"CREATE", "UPDATE"}:
         raise SystemExit("OPERATION must be CREATE or UPDATE")
+    
+    def block():
+        source_file = out_dir / "createRTP.ndjson" if op_env == "UPDATE" else None
 
-    source_file = out_dir / "createRTP.ndjson" if op_env == "UPDATE" else None
+        out_path = write_file(out_dir, rows, op_env, source_file)
+        print(f"[generator] {op_env} -> {out_path.resolve()}")
+        generate_search_file(out_dir)
 
-    out_path = write_file(out_dir, rows, op_env, source_file)
-    print(f"[generator] {op_env} -> {out_path.resolve()}")
-    generate_search_file(out_dir)
-
-    result = send_file_to_api(out_path)
-    print("[uploader] Response:")
-    print(json.dumps(result, indent=2))
+        result = send_file_to_api(out_path)
+        print("[uploader] Response:")
+        print(json.dumps(result, indent=2))
+    
+    run_continuously(mins, block)
 
 
 if __name__ == "__main__":

--- a/load-tests/send_to_gpd_queue.py
+++ b/load-tests/send_to_gpd_queue.py
@@ -4,7 +4,7 @@ import os
 from collections.abc import Iterable, Iterator
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from datetime import datetime, timedelta
+from typing import Callable
 import requests
 from dotenv import load_dotenv
 from utilities import random_iuv, require_env, require_env_or_default, to_epoch_millis
@@ -26,7 +26,7 @@ def generate_create_records(count: int) -> Iterable[dict]:
     debtor_cf = require_env("FISCAL_CODE")
 
     for i in range(count):
-        due = to_epoch_millis(now + timedelta(days=30, seconds=i))
+        due = to_epoch_millis(now + timedelta(days=30))
         iuv = random_iuv(17)
         yield {
             "id": random_iuv(10),
@@ -141,7 +141,7 @@ def send_file_to_api(path: Path) -> dict:
 
     with path.open("rb") as fh:
         files = {"file": (path.name, fh, "application/x-ndjson")}
-        resp = requests.post(api_url, params=params, files=files, timeout=30000)
+        resp = requests.post(api_url, params=params, files=files, timeout=300)
     try:
         resp.raise_for_status()
     except requests.HTTPError:
@@ -149,7 +149,7 @@ def send_file_to_api(path: Path) -> dict:
     return resp.json()
 
 
-def run_continuously(timelength_minutes: float, block: callable[[], None]):
+def run_continuously(timelength_minutes: float, block: Callable[[], None]):
     """Utility function to run a block of code continuously for a specified duration in minutes.
     If the duration is less than 0.01 minutes (i.e., less than 0.6 seconds), the block will be executed only once.
     Args:
@@ -157,7 +157,9 @@ def run_continuously(timelength_minutes: float, block: callable[[], None]):
         block (callable[[], None]): The block of code to execute, which takes no arguments and returns None.
     """
     # If the specified duration is very short, run the block once without entering the loop
-    if abs(timelength_minutes) < 0.01:
+    if timelength_minutes < 0:
+        raise ValueError("timelength_minutes must be non-negative")
+    if timelength_minutes < 0.01:
         block()
         return
     deadline = datetime.now() + timedelta(minutes=timelength_minutes)

--- a/load-tests/utilities.py
+++ b/load-tests/utilities.py
@@ -45,7 +45,7 @@ def require_env(name: str) -> str:
 
 def require_env_or_default(name: str, default: str) -> str:
     val = os.getenv(name)
-    if not val:
+    if val is None:
         return default
     return val
 

--- a/load-tests/utilities.py
+++ b/load-tests/utilities.py
@@ -43,5 +43,12 @@ def require_env(name: str) -> str:
     return val
 
 
+def require_env_or_default(name: str, default: str) -> str:
+    val = os.getenv(name)
+    if not val:
+        return default
+    return val
+
+
 def to_epoch_millis(dt: datetime) -> int:
     return int(dt.timestamp() * 1000)


### PR DESCRIPTION
### Description

This PR improves the GPD queue load test script (`send_to_gpd_queue.py`) to support continuous execution for a configurable duration. Previously the script sent a single batch and exited; now it loops until a `MINUTES` deadline, making it suitable for sustained load testing scenarios. A new utility function `require_env_or_default` is also introduced to support optional environment variables with fallback values.

### List of changes

- `load-tests/send_to_gpd_queue.py`: refactored `main()` to support continuous execution via the new `run_continuously()` helper; `MINUTES` is now an optional env var (defaults to `0`, meaning single run); timestamp for each record is now set to `datetime.now(UTC)` at generation time; HTTP timeout increased to `30000`
- `load-tests/utilities.py`: added `require_env_or_default(name, default)` utility to retrieve an optional environment variable with a fallback value

### Motivation and context

During load testing sessions it was necessary to sustain a target message rate (e.g. ~6 msg/s) for an extended period (e.g. 30–60 minutes). The previous script only sent one batch, requiring manual re-execution.

### Aggregation level

- [ ] Test case
- [x] Test suite

### Test type

- [ ] Functional test
- [ ] Bdd test
- [x] Performance
- [ ] End to end

### Type of changes

- [ ] Add new test case/suite
- [x] Modify existing test case/suite

### Test Results

- [ ] Success
- [ ] Failure
- [ ] Poor performance
- [ ] Good performance

### Did you update secrets accordingly?

- [ ] Yes
- [x] Not needed

### Did you update dependencies accordingly?

- [ ] Yes
- [x] Not needed

### Other information

The `MINUTES` env var is optional. If omitted or set to `0`, the script runs a single batch (backward-compatible with the previous behaviour). Errors during individual iterations are caught and logged so the loop continues until the deadline rather than aborting.
