### PR TITLE
fix: [SRTP-1810] update resourceID to resourceId in idempotency asser…

### DIFF
--- a/functional-tests/tests/process_messages_sender/test_RTP_process_sender_IDEMPOTENCY.py
+++ b/functional-tests/tests/process_messages_sender/test_RTP_process_sender_IDEMPOTENCY.py
@@ -24,7 +24,7 @@ def test_send_gpd_message_create_idempotency(
 
     Expectations:
     - Both calls return HTTP 200 (idempotent, not an error).
-    - The resourceID in both responses is identical, proving the API returned
+    - The resourceId in both responses is identical, proving the API returned
       the cached response and did not process the message twice.
     - Querying by notice number returns exactly one RTP, confirming that only
       one record was written to the database.
@@ -47,12 +47,12 @@ def test_send_gpd_message_create_idempotency(
     body_first = response_first.json()
     body_second = response_second.json()
 
-    assert "resourceID" in body_first, f"Expected 'resourceID' in first response body, got: {response_first.text}"
-    assert "resourceID" in body_second, f"Expected 'resourceID' in second response body, got: {response_second.text}"
+    assert "resourceId" in body_first, f"Expected 'resourceId' in first response body, got: {response_first.text}"
+    assert "resourceId" in body_second, f"Expected 'resourceId' in second response body, got: {response_second.text}"
 
-    assert body_first["resourceID"] == body_second["resourceID"], (
-        f"Expected both calls to return the same resourceID (idempotency), "
-        f"but got '{body_first['resourceID']}' and '{body_second['resourceID']}'"
+    assert body_first["resourceId"] == body_second["resourceId"], (
+        f"Expected both calls to return the same resourceId (idempotency), "
+        f"but got '{body_first['resourceId']}' and '{body_second['resourceId']}'"
     )
 
     by_notice = get_rtp_by_notice_number(


### PR DESCRIPTION
### Description

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

update `resourceID` to `resourceId` in idempotency assertions

### List of changes

<!--- Describe your changes in detail -->

- Update resourceID to resourceId in `test_send_gpd_message_create_idempotency`.
### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

Align the idempotency test assertion with the camelCase API schema.

### Aggregation level

<!--- Did you write a single reusable test case, or a full test suite?  -->

- [ ] Test case
- [x] Test suite

### Test type

- [x] Functional test
- [ ] Bdd test
- [ ] Performance
- [ ] End to end
- [ ] Performance

### Type of changes

- [ ] Add new test case/suite
- [x] Modify existing test case/suite

### Test Results

- [x] Success
- [ ] Failure
- [ ] Poor performance
- [ ] Good performance

### Did you update secrets accordingly?

- [ ] Yes
  - [ ] `.secrets_template.yaml`
  - [ ] Pipelines' secure file
  - [ ] Confluence
- [x] Not needed
- [ ] No (_please provide further information_)

### Did you update dependencies accordingly?

- [ ] Yes (which requirements.txt did you update?)
<!--- Describe which requirements.txt did you update -->
- [x] Not needed


### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
