### PR TITLE
fix: [SRTP-1811] update resourceID to resourceId in update_before_create

### DIFF
--- a/functional-tests/tests/process_messages_sender/test_RTP_process_sender_UPDATE_before_CREATE.py
+++ b/functional-tests/tests/process_messages_sender/test_RTP_process_sender_UPDATE_before_CREATE.py
@@ -47,9 +47,9 @@ def test_send_gpd_message_update_valid_before_create_rtp_exists(
     assert_response_code(response_update, 200, "UPDATE before CREATE", "VALID")
 
     response_update_json = response_update.json()
-    assert "resourceID" in response_update_json, f"Expected 'resourceID' in response body, got: {response_update.text}"
-    resource_id = response_update_json["resourceID"]
+    assert "resourceId" in response_update_json, f"Expected 'resourceId' in response body, got: {response_update.text}"
+    resource_id = response_update_json["resourceId"]
 
     get_response = get_rtp(access_token=rtp_reader_access_token, rtp_id=resource_id)
     assert get_response.status_code == 200, f"Expected RTP to exist in DB, got {get_response.status_code}"
-    assert get_response.json()["resourceID"] == resource_id
+    assert get_response.json()["resourceId"] == resource_id


### PR DESCRIPTION
### Description

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

update resourceID to resourceId in update before create test

### List of changes

<!--- Describe your changes in detail -->
- Update `resourceID` to `resourceId` in the `test_send_gpd_message_update_valid_before_create_rtp_exists` test assertions.

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

Align the test assertions with the new camelCase API schema.
### Aggregation level

<!--- Did you write a single reusable test case, or a full test suite?  -->

- [ ] Test case
- [x] Test suite

### Test type

- [x] Functional test
- [ ] Bdd test
- [ ] Performance
- [ ] End to end
- [ ] Performance

### Type of changes

- [ ] Add new test case/suite
- [x] Modify existing test case/suite

### Test Results

- [ ] Success
- [ ] Failure
- [ ] Poor performance
- [ ] Good performance

### Did you update secrets accordingly?

- [ ] Yes
  - [ ] `.secrets_template.yaml`
  - [ ] Pipelines' secure file
  - [ ] Confluence
- [x] Not needed
- [ ] No (_please provide further information_)

### Did you update dependencies accordingly?

- [ ] Yes (which requirements.txt did you update?)
<!--- Describe which requirements.txt did you update -->
- [x] Not needed


### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
