### PR TITLE
fix: [SRTP-1816] fix mock RJCT tests by removing unnecessary debtor activation step

### DIFF
--- a/functional-tests/tests/send_rtp/test_RTP_send_MOCK.py
+++ b/functional-tests/tests/send_rtp/test_RTP_send_MOCK.py
@@ -196,11 +196,11 @@ def test_send_rtp_sync_sent_extra_field(
 @pytest.mark.send
 @pytest.mark.unhappy_path
 def test_send_rtp_sync_rejected_with_extra_fields(
-    creditor_service_provider_token_a,
+    rtp_consumer_access_token,
     rtp_reader_access_token,
 ):
     status = send_rtp_and_get_status_by_notice_number_mock_only(
-        creditor_service_provider_token_a,
+        rtp_consumer_access_token,
         rtp_reader_access_token,
         secrets.mock_rjct_extra_field_fiscal_code,
     )
@@ -215,11 +215,11 @@ def test_send_rtp_sync_rejected_with_extra_fields(
 @pytest.mark.send
 @pytest.mark.unhappy_path
 def test_send_rtp_sync_rejected_no_links(
-    creditor_service_provider_token_a,
+    rtp_consumer_access_token,
     rtp_reader_access_token,
 ):
     status = send_rtp_and_get_status_by_notice_number_mock_only(
-        creditor_service_provider_token_a,
+        rtp_consumer_access_token,
         rtp_reader_access_token,
         secrets.mock_rjct_no_links_fiscal_code,
     )

--- a/functional-tests/tests/send_rtp/test_RTP_send_MOCK.py
+++ b/functional-tests/tests/send_rtp/test_RTP_send_MOCK.py
@@ -6,7 +6,9 @@ from api.RTP_send_api import send_rtp
 from config.configuration import config, secrets
 from utils.dataset_RTP_data import generate_rtp_data
 from utils.regex_utils import uuidv4_pattern
-from utils.rtp_send_helpers import send_rtp_and_get_status, send_rtp_and_get_status_by_notice_number
+from utils.rtp_send_helpers import (send_rtp_and_get_status,
+                                    send_rtp_and_get_status_by_notice_number,
+                                    send_rtp_and_get_status_by_notice_number_mock_only)
 
 
 @allure.epic("RTP Send")
@@ -194,12 +196,10 @@ def test_send_rtp_sync_sent_extra_field(
 @pytest.mark.send
 @pytest.mark.unhappy_path
 def test_send_rtp_sync_rejected_with_extra_fields(
-    debtor_service_provider_token_a,
     creditor_service_provider_token_a,
     rtp_reader_access_token,
 ):
-    status = send_rtp_and_get_status_by_notice_number(
-        debtor_service_provider_token_a,
+    status = send_rtp_and_get_status_by_notice_number_mock_only(
         creditor_service_provider_token_a,
         rtp_reader_access_token,
         secrets.mock_rjct_extra_field_fiscal_code,
@@ -215,12 +215,10 @@ def test_send_rtp_sync_rejected_with_extra_fields(
 @pytest.mark.send
 @pytest.mark.unhappy_path
 def test_send_rtp_sync_rejected_no_links(
-    debtor_service_provider_token_a,
     creditor_service_provider_token_a,
     rtp_reader_access_token,
 ):
-    status = send_rtp_and_get_status_by_notice_number(
-        debtor_service_provider_token_a,
+    status = send_rtp_and_get_status_by_notice_number_mock_only(
         creditor_service_provider_token_a,
         rtp_reader_access_token,
         secrets.mock_rjct_no_links_fiscal_code,

--- a/utils/rtp_send_helpers.py
+++ b/utils/rtp_send_helpers.py
@@ -103,7 +103,7 @@ def send_rtp_and_get_status_by_notice_number_mock_only(
     notice_number = message_payload["nav"]
 
     response = send_gpd_message(access_token=rtp_consumer_token, message_payload=message_payload)
-    assert response.status_code == expected_send_status
+    assert response.status_code == expected_send_status, "Service Provider rejection."
 
     status = get_status_from_notice_number(reader_token, notice_number)
 

--- a/utils/rtp_send_helpers.py
+++ b/utils/rtp_send_helpers.py
@@ -73,6 +73,39 @@ def send_rtp_and_get_status_by_notice_number(
 
     return status
 
+def send_rtp_and_get_status_by_notice_number_mock_only(
+    creditor_token: str,
+    reader_token: str,
+    payer_id: str,
+    expected_send_status: int = 422,
+) -> str:
+    """Send an RTP without debtor activation and return the resulting status by notice number.
+
+    Intended for mock-only scenarios where the payer fiscal code is pre-configured
+    in the mock EPC to trigger a specific synchronous response (e.g. RJCT with extra
+    fields or missing _links), making the activation step unnecessary.
+
+    Args:
+        creditor_token: Bearer token for the creditor service provider.
+        reader_token: Bearer token for the RTP reader.
+        payer_id: Fiscal code used as payer ID (drives the mock EPC response).
+        expected_send_status: Expected HTTP status code from the send RTP call (must be >= 400).
+
+    Returns:
+        The RTP status string (e.g. "REJECTED").
+    """
+    assert expected_send_status >= 400
+
+    rtp_data = generate_rtp_data(payer_id=payer_id)
+    notice_number = rtp_data["paymentNotice"]["noticeNumber"]
+
+    send_response = send_rtp(access_token=creditor_token, rtp_payload=rtp_data)
+    assert send_response.status_code == expected_send_status
+
+    status = get_status_from_notice_number(reader_token, notice_number)
+
+    return status
+
 
 def get_status_from_notice_number(access_token: str, notice_number: str) -> str:
     rtp_data = get_rtp_by_notice_number(access_token, notice_number)

--- a/utils/rtp_send_helpers.py
+++ b/utils/rtp_send_helpers.py
@@ -1,7 +1,5 @@
 """Helper functions for RTP send flows used across functional tests."""
 
-import time
-
 from api.RTP_process_sender import send_gpd_message
 from utils.dataset_gpd_message import generate_gpd_message_payload
 from api.debtor_activation_api import activate

--- a/utils/rtp_send_helpers.py
+++ b/utils/rtp_send_helpers.py
@@ -1,5 +1,9 @@
 """Helper functions for RTP send flows used across functional tests."""
 
+import time
+
+from api.RTP_process_sender import send_gpd_message
+from utils.dataset_gpd_message import generate_gpd_message_payload
 from api.debtor_activation_api import activate
 from api.RTP_get_api import get_rtp
 from api.RTP_get_api import get_rtp_by_notice_number as api_get_rtp_by_notice_number
@@ -74,33 +78,34 @@ def send_rtp_and_get_status_by_notice_number(
     return status
 
 def send_rtp_and_get_status_by_notice_number_mock_only(
-    creditor_token: str,
+    rtp_consumer_token: str,
     reader_token: str,
     payer_id: str,
     expected_send_status: int = 422,
 ) -> str:
-    """Send an RTP without debtor activation and return the resulting status by notice number.
+    """Send a GPD message and return the resulting RTP status by notice number.
 
     Intended for mock-only scenarios where the payer fiscal code is pre-configured
-    in the mock EPC to trigger a specific synchronous response (e.g. RJCT with extra
-    fields or missing _links), making the activation step unnecessary.
+    in the mock EPC to trigger a specific synchronous RJCT response (e.g. with extra
+    fields or missing _links). Uses the GPD message flow instead of the direct RTP
+    send flow, so no debtor activation is required.
 
     Args:
-        creditor_token: Bearer token for the creditor service provider.
+        rtp_consumer_token: Bearer token for the RTP consumer (GPD message sender).
         reader_token: Bearer token for the RTP reader.
         payer_id: Fiscal code used as payer ID (drives the mock EPC response).
-        expected_send_status: Expected HTTP status code from the send RTP call (must be >= 400).
+        expected_send_status: Expected HTTP status code from the GPD message call (must be >= 400).
 
     Returns:
         The RTP status string (e.g. "REJECTED").
     """
     assert expected_send_status >= 400
 
-    rtp_data = generate_rtp_data(payer_id=payer_id)
-    notice_number = rtp_data["paymentNotice"]["noticeNumber"]
+    message_payload = generate_gpd_message_payload(fiscal_code=payer_id, operation="CREATE", status="VALID")
+    notice_number = message_payload["nav"]
 
-    send_response = send_rtp(access_token=creditor_token, rtp_payload=rtp_data)
-    assert send_response.status_code == expected_send_status
+    response = send_gpd_message(access_token=rtp_consumer_token, message_payload=message_payload)
+    assert response.status_code == expected_send_status
 
     status = get_status_from_notice_number(reader_token, notice_number)
 


### PR DESCRIPTION
### Description

This PR fixes two mock functional tests for synchronous RTP rejection scenarios that were previously failing.
The tests `test_send_rtp_sync_rejected_with_extra_fields` and `test_send_rtp_sync_rejected_no_links` were calling `send_rtp_and_get_status_by_notice_number`, which sends an RTP directly via the creditor SP flow and includes a debtor activation step. However, these scenarios require the GPD message flow (`send_gpd_message`) with an `rtp_consumer` token, since the mock EPC is configured to respond to specific fiscal codes
(`MOCK_RJCT_EXTRA_FIELD_FISCAL_CODE`, `MOCK_RJCT_NO_LINKS_FISCAL_CODE`) with a synchronous                                                                                         RJCT only through that flow. A dedicated helper `send_rtp_and_get_status_by_notice_number_mock_only` was
introduced to handle this case cleanly.


### List of changes

- Added `send_rtp_and_get_status_by_notice_number_mock_only` helper in `utils/rtp_send_helpers.py`: sends an
  RTP and retrieves its status by notice number without performing debtor activation, intended for mock-only
  scenarios with pre-configured fiscal codes
- Updated `test_send_rtp_sync_rejected_with_extra_fields` and `test_send_rtp_sync_rejected_no_links` in
  `functional-tests/tests/send_rtp/test_RTP_send_MOCK.py` to use the new helper and removed the unnecessary
  `debtor_service_provider_token_a` fixture from both tests

### Motivation and context

The two RJCT mock tests were failing because they were trying to activate a debtor before sending the RTP.
The mock EPC responds to specific fiscal codes with a pre-defined synchronous RJCT payload (with extra fields
or missing `_links`), regardless of activation state. Using the activation-based helper caused the tests to
fail in the activation step rather than exercising the intended rejection flow.

### Aggregation level

- [ ] Test case
- [x] Test suite

### Test type

- [x] Functional test
- [ ] Bdd test
- [ ] Performance
- [ ] End to end
- [ ] Performance

### Type of changes

- [ ] Add new test case/suite
- [x] Modify existing test case/suite

### Test Results

- [x] Success
- [ ] Failure
- [ ] Poor performance
- [ ] Good performance

### Did you update secrets accordingly?

- [ ] Yes
  - [ ] `.secrets_template.yaml`
  - [ ] Pipelines' secure file
  - [ ] Confluence
- [x] Not needed
- [ ] No (_please provide further information_)

### Did you update dependencies accordingly?

- [ ] Yes (which requirements.txt did you update?)
- [x] Not needed


### Other information

Both tests pass after the fix:
- `test_send_rtp_sync_rejected_with_extra_fields` — PASSED
- `test_send_rtp_sync_rejected_no_links` — PASSED