### PR TITLE
feat: [SRTP-1934] change status code to 422 in test_expectations

### DIFF
--- a/utils/test_expectations.py
+++ b/utils/test_expectations.py
@@ -6,12 +6,12 @@ Defines expected status codes and body presence for different operations and sta
 # CREATE
 CREATE_EXPECTED_CODES = {
     "VALID": 200,
-    "INVALID": 400,
-    "PARTIALLY_PAID": 400,
-    "PAID": 400,
-    "PUBLISHED": 400,
-    "EXPIRED": 400,
-    "DRAFT": 400,
+    "INVALID": 422,
+    "PARTIALLY_PAID": 422,
+    "PAID": 422,
+    "PUBLISHED": 422,
+    "EXPIRED": 422,
+    "DRAFT": 422,
 }
 
 # UPDATE post CREATE VALID
@@ -21,19 +21,19 @@ UPDATE_EXPECTED_CODES = {
     "PAID": 200,
     "EXPIRED": 200,
     "DRAFT": 200,
-    "PARTIALLY_PAID": 400,
-    "PUBLISHED": 400,
+    "PARTIALLY_PAID": 422,
+    "PUBLISHED": 422,
 }
 
 # UPDATE standalone (no prior CREATE)
 UPDATE_BEFORE_CREATE_CODES = {
     "VALID": 200,
-    "INVALID": 404,
-    "PAID": 404,
-    "EXPIRED": 404,
-    "DRAFT": 404,
-    "PARTIALLY_PAID": 400,
-    "PUBLISHED": 400,
+    "INVALID": 422,
+    "PAID": 422,
+    "EXPIRED": 422,
+    "DRAFT": 422,
+    "PARTIALLY_PAID": 422,
+    "PUBLISHED": 422,
 }
 
 # UPDATE post CREATE VALID and DELETE
@@ -43,19 +43,19 @@ UPDATE_AFTER_CREATE_AND_DELETE_CODES = {
     "PAID": 422,
     "EXPIRED": 422,
     "DRAFT": 422,
-    "PARTIALLY_PAID": 400,
-    "PUBLISHED": 400,
+    "PARTIALLY_PAID": 422,
+    "PUBLISHED": 422,
 }
 
 # DELETE post CREATE (status refers to the CREATE status)
 DELETE_AFTER_CREATE_CODES = {
     "VALID": 200,
-    "INVALID": 404,
-    "PARTIALLY_PAID": 404,
-    "PAID": 404,
-    "PUBLISHED": 404,
-    "EXPIRED": 404,
-    "DRAFT": 404,
+    "INVALID": 422,
+    "PARTIALLY_PAID": 422,
+    "PAID": 422,
+    "PUBLISHED": 422,
+    "EXPIRED": 422,
+    "DRAFT": 422,
 }
 
 # DELETE post CREATE VALID and UPDATE (status refers to the UPDATE status)
@@ -72,12 +72,12 @@ DELETE_AFTER_UPDATE_CODES = {
 # DELETE post standalone UPDATE (status refers to the UPDATE status)
 DELETE_AFTER_UPDATE_STANDALONE_CODES = {
     "VALID": 200,
-    "INVALID": 404,
-    "PARTIALLY_PAID": 404,
-    "PAID": 404,
-    "PUBLISHED": 404,
-    "EXPIRED": 404,
-    "DRAFT": 404,
+    "INVALID": 422,
+    "PARTIALLY_PAID": 422,
+    "PAID": 422,
+    "PUBLISHED": 422,
+    "EXPIRED": 422,
+    "DRAFT": 422,
 }
 
 STATUSES_WITH_BODY = {"VALID"}


### PR DESCRIPTION
### Description

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

Aligned functional tests in rtp-platform-qa with rtp-sender behavior, which now returns HTTP 422 (instead of 400 or 404) for invalid statuses and state transitions.

### List of changes

<!--- Describe your changes in detail -->

- Updated expected response codes for invalid states to 422 in utils/test_expectations.py.

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

The microservice now returns 422 Unprocessable Entity for invalid message statuses to distinguish business logic failures from structural errors (400)

### Aggregation level

<!--- Did you write a single reusable test case, or a full test suite?  -->

- [ ] Test case
- [x] Test suite

### Test type

- [x] Functional test
- [ ] Bdd test
- [ ] Performance
- [ ] End to end
- [ ] Performance

### Type of changes

- [ ] Add new test case/suite
- [x] Modify existing test case/suite

### Test Results

- [ ] Success
- [ ] Failure
- [ ] Poor performance
- [ ] Good performance

### Did you update secrets accordingly?

- [ ] Yes
  - [ ] `.secrets_template.yaml`
  - [ ] Pipelines' secure file
  - [ ] Confluence
- [x] Not needed
- [ ] No (_please provide further information_)

### Did you update dependencies accordingly?

- [ ] Yes (which requirements.txt did you update?)
<!--- Describe which requirements.txt did you update -->
- [ ] Not needed


### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
