### PR TITLE
feat: [SRTP-1945] add test coverage for omocodia, foreign fiscal code, and Partita IVA  

### DIFF
--- a/functional-tests/tests/activation/test_debtor_activation_create.py
+++ b/functional-tests/tests/activation/test_debtor_activation_create.py
@@ -103,14 +103,9 @@ def test_fail_activate_debtor_two_times(debtor_service_provider_token_a, random_
 @pytest.mark.auth
 @pytest.mark.activation
 @pytest.mark.happy_path
-def test_activate_debtor_with_omocodia_fiscal_code(debtor_service_provider_token_a, random_omocodia_fiscal_code):
+def test_activate_debtor_with_omocodia_fiscal_code(debtor_service_provider_token_a, activate_payer, random_omocodia_fiscal_code):
 
-    res = activate(
-        debtor_service_provider_token_a,
-        random_omocodia_fiscal_code,
-        secrets.debtor_service_provider.service_provider_id,
-    )
-    assert res.status_code == 201, f"Expected 201 but got {res.status_code}: {res.text}"
+    activate_payer(random_omocodia_fiscal_code)
 
     res = get_activation_by_payer_id(debtor_service_provider_token_a, random_omocodia_fiscal_code)
     assert res.status_code == 200
@@ -125,14 +120,9 @@ def test_activate_debtor_with_omocodia_fiscal_code(debtor_service_provider_token
 @pytest.mark.auth
 @pytest.mark.activation
 @pytest.mark.happy_path
-def test_activate_debtor_with_foreign_fiscal_code(debtor_service_provider_token_a, random_foreign_fiscal_code):
+def test_activate_debtor_with_foreign_fiscal_code(debtor_service_provider_token_a, activate_payer, random_foreign_fiscal_code):
 
-    res = activate(
-        debtor_service_provider_token_a,
-        random_foreign_fiscal_code,
-        secrets.debtor_service_provider.service_provider_id,
-    )
-    assert res.status_code == 201, f"Expected 201 but got {res.status_code}: {res.text}"
+    activate_payer(random_foreign_fiscal_code)
 
     res = get_activation_by_payer_id(debtor_service_provider_token_a, random_foreign_fiscal_code)
     assert res.status_code == 200
@@ -147,14 +137,9 @@ def test_activate_debtor_with_foreign_fiscal_code(debtor_service_provider_token_
 @pytest.mark.auth
 @pytest.mark.activation
 @pytest.mark.happy_path
-def test_activate_debtor_with_vat_number(debtor_service_provider_token_a, random_vat_number):
+def test_activate_debtor_with_vat_number(debtor_service_provider_token_a, activate_payer, random_vat_number):
 
-    res = activate(
-        debtor_service_provider_token_a,
-        random_vat_number,
-        secrets.debtor_service_provider.service_provider_id,
-    )
-    assert res.status_code == 201, f"Expected 201 but got {res.status_code}: {res.text}"
+    activate_payer(random_vat_number)
 
     res = get_activation_by_payer_id(debtor_service_provider_token_a, random_vat_number)
     assert res.status_code == 200

--- a/functional-tests/tests/activation/test_debtor_activation_create.py
+++ b/functional-tests/tests/activation/test_debtor_activation_create.py
@@ -98,6 +98,28 @@ def test_fail_activate_debtor_two_times(debtor_service_provider_token_a, random_
 @allure.epic("Debtor Activation")
 @allure.feature("Activation")
 @allure.story("Debtor activation")
+@allure.title("A debtor with omocodia fiscal code is activated successfully")
+@allure.tag("functional", "happy_path", "activation", "debtor_activation", "omocodia")
+@pytest.mark.auth
+@pytest.mark.activation
+@pytest.mark.happy_path
+def test_activate_debtor_with_omocodia_fiscal_code(debtor_service_provider_token_a, random_omocodia_fiscal_code):
+
+    res = activate(
+        debtor_service_provider_token_a,
+        random_omocodia_fiscal_code,
+        secrets.debtor_service_provider.service_provider_id,
+    )
+    assert res.status_code == 201, f"Expected 201 but got {res.status_code}: {res.text}"
+
+    res = get_activation_by_payer_id(debtor_service_provider_token_a, random_omocodia_fiscal_code)
+    assert res.status_code == 200
+    assert res.json()["payer"]["fiscalCode"] == random_omocodia_fiscal_code
+
+
+@allure.epic("Debtor Activation")
+@allure.feature("Activation")
+@allure.story("Debtor activation")
 @allure.title("The activation request must contain lower case fiscal code")
 @allure.tag("functional", "unhappy_path", "activation", "debtor_activation")
 @pytest.mark.auth

--- a/functional-tests/tests/activation/test_debtor_activation_create.py
+++ b/functional-tests/tests/activation/test_debtor_activation_create.py
@@ -142,6 +142,28 @@ def test_activate_debtor_with_foreign_fiscal_code(debtor_service_provider_token_
 @allure.epic("Debtor Activation")
 @allure.feature("Activation")
 @allure.story("Debtor activation")
+@allure.title("A debtor with VAT number (Partita IVA) is activated successfully")
+@allure.tag("functional", "happy_path", "activation", "debtor_activation", "vat")
+@pytest.mark.auth
+@pytest.mark.activation
+@pytest.mark.happy_path
+def test_activate_debtor_with_vat_number(debtor_service_provider_token_a, random_vat_number):
+
+    res = activate(
+        debtor_service_provider_token_a,
+        random_vat_number,
+        secrets.debtor_service_provider.service_provider_id,
+    )
+    assert res.status_code == 201, f"Expected 201 but got {res.status_code}: {res.text}"
+
+    res = get_activation_by_payer_id(debtor_service_provider_token_a, random_vat_number)
+    assert res.status_code == 200
+    assert res.json()["payer"]["fiscalCode"] == random_vat_number
+
+
+@allure.epic("Debtor Activation")
+@allure.feature("Activation")
+@allure.story("Debtor activation")
 @allure.title("The activation request must contain lower case fiscal code")
 @allure.tag("functional", "unhappy_path", "activation", "debtor_activation")
 @pytest.mark.auth

--- a/functional-tests/tests/activation/test_debtor_activation_create.py
+++ b/functional-tests/tests/activation/test_debtor_activation_create.py
@@ -103,7 +103,9 @@ def test_fail_activate_debtor_two_times(debtor_service_provider_token_a, random_
 @pytest.mark.auth
 @pytest.mark.activation
 @pytest.mark.happy_path
-def test_activate_debtor_with_omocodia_fiscal_code(debtor_service_provider_token_a, activate_payer, random_omocodia_fiscal_code):
+def test_activate_debtor_with_omocodia_fiscal_code(
+    debtor_service_provider_token_a, activate_payer, random_omocodia_fiscal_code
+):
 
     activate_payer(random_omocodia_fiscal_code)
 
@@ -120,7 +122,9 @@ def test_activate_debtor_with_omocodia_fiscal_code(debtor_service_provider_token
 @pytest.mark.auth
 @pytest.mark.activation
 @pytest.mark.happy_path
-def test_activate_debtor_with_foreign_fiscal_code(debtor_service_provider_token_a, activate_payer, random_foreign_fiscal_code):
+def test_activate_debtor_with_foreign_fiscal_code(
+    debtor_service_provider_token_a, activate_payer, random_foreign_fiscal_code
+):
 
     activate_payer(random_foreign_fiscal_code)
 

--- a/functional-tests/tests/activation/test_debtor_activation_create.py
+++ b/functional-tests/tests/activation/test_debtor_activation_create.py
@@ -120,6 +120,28 @@ def test_activate_debtor_with_omocodia_fiscal_code(debtor_service_provider_token
 @allure.epic("Debtor Activation")
 @allure.feature("Activation")
 @allure.story("Debtor activation")
+@allure.title("A debtor with foreign fiscal code is activated successfully")
+@allure.tag("functional", "happy_path", "activation", "debtor_activation", "foreign")
+@pytest.mark.auth
+@pytest.mark.activation
+@pytest.mark.happy_path
+def test_activate_debtor_with_foreign_fiscal_code(debtor_service_provider_token_a, random_foreign_fiscal_code):
+
+    res = activate(
+        debtor_service_provider_token_a,
+        random_foreign_fiscal_code,
+        secrets.debtor_service_provider.service_provider_id,
+    )
+    assert res.status_code == 201, f"Expected 201 but got {res.status_code}: {res.text}"
+
+    res = get_activation_by_payer_id(debtor_service_provider_token_a, random_foreign_fiscal_code)
+    assert res.status_code == 200
+    assert res.json()["payer"]["fiscalCode"] == random_foreign_fiscal_code
+
+
+@allure.epic("Debtor Activation")
+@allure.feature("Activation")
+@allure.story("Debtor activation")
 @allure.title("The activation request must contain lower case fiscal code")
 @allure.tag("functional", "unhappy_path", "activation", "debtor_activation")
 @pytest.mark.auth

--- a/functional-tests/tests/activation/test_debtor_activation_get.py
+++ b/functional-tests/tests/activation/test_debtor_activation_get.py
@@ -41,7 +41,9 @@ def test_get_activation_by_id(debtor_service_provider_token_a, make_activation):
 @pytest.mark.auth
 @pytest.mark.activation
 @pytest.mark.happy_path
-def test_get_activation_by_id_omocodia_fiscal_code(debtor_service_provider_token_a, make_activation, random_omocodia_fiscal_code):
+def test_get_activation_by_id_omocodia_fiscal_code(
+    debtor_service_provider_token_a, make_activation, random_omocodia_fiscal_code
+):
 
     activation_id, _ = make_activation(random_omocodia_fiscal_code)
 
@@ -66,7 +68,9 @@ def test_get_activation_by_id_omocodia_fiscal_code(debtor_service_provider_token
 @pytest.mark.auth
 @pytest.mark.activation
 @pytest.mark.happy_path
-def test_get_activation_by_id_foreign_fiscal_code(debtor_service_provider_token_a, make_activation, random_foreign_fiscal_code):
+def test_get_activation_by_id_foreign_fiscal_code(
+    debtor_service_provider_token_a, make_activation, random_foreign_fiscal_code
+):
 
     activation_id, _ = make_activation(random_foreign_fiscal_code)
 

--- a/functional-tests/tests/activation/test_debtor_activation_get.py
+++ b/functional-tests/tests/activation/test_debtor_activation_get.py
@@ -61,6 +61,31 @@ def test_get_activation_by_id_omocodia_fiscal_code(debtor_service_provider_token
 @allure.epic("Debtor Activation")
 @allure.feature("Activation")
 @allure.story("Get Debtor activation by ID")
+@allure.title("A debtor with foreign fiscal code is activated and retrieved by activation id")
+@allure.tag("functional", "happy_path", "activation", "debtor_activation", "foreign")
+@pytest.mark.auth
+@pytest.mark.activation
+@pytest.mark.happy_path
+def test_get_activation_by_id_foreign_fiscal_code(debtor_service_provider_token_a, random_foreign_fiscal_code):
+
+    res = activate(
+        debtor_service_provider_token_a,
+        random_foreign_fiscal_code,
+        secrets.debtor_service_provider.service_provider_id,
+    )
+    assert res.status_code == 201, f"Activation failed: {res.status_code} {res.text}"
+    activation_id = res.headers["Location"].rstrip("/").split("/")[-1]
+
+    res = get_activation_by_id(debtor_service_provider_token_a, activation_id)
+    assert res.status_code == 200, f"Expected 200 but got {res.status_code}"
+    body = res.json()
+    assert body["id"] == activation_id
+    assert body["payer"]["fiscalCode"] == random_foreign_fiscal_code
+
+
+@allure.epic("Debtor Activation")
+@allure.feature("Activation")
+@allure.story("Get Debtor activation by ID")
 @allure.title("Retrieving activation without valid token returns 401")
 @allure.tag("functional", "unhappy_path", "activation", "debtor_activation")
 @pytest.mark.auth

--- a/functional-tests/tests/activation/test_debtor_activation_get.py
+++ b/functional-tests/tests/activation/test_debtor_activation_get.py
@@ -86,6 +86,31 @@ def test_get_activation_by_id_foreign_fiscal_code(debtor_service_provider_token_
 @allure.epic("Debtor Activation")
 @allure.feature("Activation")
 @allure.story("Get Debtor activation by ID")
+@allure.title("A debtor with VAT number is activated and retrieved by activation id")
+@allure.tag("functional", "happy_path", "activation", "debtor_activation", "vat")
+@pytest.mark.auth
+@pytest.mark.activation
+@pytest.mark.happy_path
+def test_get_activation_by_id_vat_number(debtor_service_provider_token_a, random_vat_number):
+
+    res = activate(
+        debtor_service_provider_token_a,
+        random_vat_number,
+        secrets.debtor_service_provider.service_provider_id,
+    )
+    assert res.status_code == 201, f"Activation failed: {res.status_code} {res.text}"
+    activation_id = res.headers["Location"].rstrip("/").split("/")[-1]
+
+    res = get_activation_by_id(debtor_service_provider_token_a, activation_id)
+    assert res.status_code == 200, f"Expected 200 but got {res.status_code}"
+    body = res.json()
+    assert body["id"] == activation_id
+    assert body["payer"]["fiscalCode"] == random_vat_number
+
+
+@allure.epic("Debtor Activation")
+@allure.feature("Activation")
+@allure.story("Get Debtor activation by ID")
 @allure.title("Retrieving activation without valid token returns 401")
 @allure.tag("functional", "unhappy_path", "activation", "debtor_activation")
 @pytest.mark.auth

--- a/functional-tests/tests/activation/test_debtor_activation_get.py
+++ b/functional-tests/tests/activation/test_debtor_activation_get.py
@@ -4,7 +4,7 @@ from datetime import datetime
 import allure
 import pytest
 
-from api.debtor_activation_api import get_activation_by_id
+from api.debtor_activation_api import activate, get_activation_by_id
 from config.configuration import secrets
 
 
@@ -31,6 +31,31 @@ def test_get_activation_by_id(debtor_service_provider_token_a, make_activation):
         datetime.strptime(body["effectiveActivationDate"], "%Y-%m-%dT%H:%M:%S.%f")
     except ValueError:
         assert False, "Invalid date format"
+
+
+@allure.epic("Debtor Activation")
+@allure.feature("Activation")
+@allure.story("Get Debtor activation by ID")
+@allure.title("A debtor with omocodia fiscal code is activated and retrieved by activation id")
+@allure.tag("functional", "happy_path", "activation", "debtor_activation", "omocodia")
+@pytest.mark.auth
+@pytest.mark.activation
+@pytest.mark.happy_path
+def test_get_activation_by_id_omocodia_fiscal_code(debtor_service_provider_token_a, random_omocodia_fiscal_code):
+
+    res = activate(
+        debtor_service_provider_token_a,
+        random_omocodia_fiscal_code,
+        secrets.debtor_service_provider.service_provider_id,
+    )
+    assert res.status_code == 201, f"Activation failed: {res.status_code} {res.text}"
+    activation_id = res.headers["Location"].rstrip("/").split("/")[-1]
+
+    res = get_activation_by_id(debtor_service_provider_token_a, activation_id)
+    assert res.status_code == 200, f"Expected 200 but got {res.status_code}"
+    body = res.json()
+    assert body["id"] == activation_id
+    assert body["payer"]["fiscalCode"] == random_omocodia_fiscal_code
 
 
 @allure.epic("Debtor Activation")

--- a/functional-tests/tests/activation/test_debtor_activation_get.py
+++ b/functional-tests/tests/activation/test_debtor_activation_get.py
@@ -4,7 +4,7 @@ from datetime import datetime
 import allure
 import pytest
 
-from api.debtor_activation_api import activate, get_activation_by_id
+from api.debtor_activation_api import get_activation_by_id
 from config.configuration import secrets
 
 
@@ -41,21 +41,21 @@ def test_get_activation_by_id(debtor_service_provider_token_a, make_activation):
 @pytest.mark.auth
 @pytest.mark.activation
 @pytest.mark.happy_path
-def test_get_activation_by_id_omocodia_fiscal_code(debtor_service_provider_token_a, random_omocodia_fiscal_code):
+def test_get_activation_by_id_omocodia_fiscal_code(debtor_service_provider_token_a, make_activation, random_omocodia_fiscal_code):
 
-    res = activate(
-        debtor_service_provider_token_a,
-        random_omocodia_fiscal_code,
-        secrets.debtor_service_provider.service_provider_id,
-    )
-    assert res.status_code == 201, f"Activation failed: {res.status_code} {res.text}"
-    activation_id = res.headers["Location"].rstrip("/").split("/")[-1]
+    activation_id, _ = make_activation(random_omocodia_fiscal_code)
 
     res = get_activation_by_id(debtor_service_provider_token_a, activation_id)
     assert res.status_code == 200, f"Expected 200 but got {res.status_code}"
     body = res.json()
     assert body["id"] == activation_id
     assert body["payer"]["fiscalCode"] == random_omocodia_fiscal_code
+    assert body["payer"]["rtpSpId"] == secrets.debtor_service_provider.service_provider_id
+
+    try:
+        datetime.strptime(body["effectiveActivationDate"], "%Y-%m-%dT%H:%M:%S.%f")
+    except ValueError:
+        assert False, "Invalid date format"
 
 
 @allure.epic("Debtor Activation")
@@ -66,21 +66,21 @@ def test_get_activation_by_id_omocodia_fiscal_code(debtor_service_provider_token
 @pytest.mark.auth
 @pytest.mark.activation
 @pytest.mark.happy_path
-def test_get_activation_by_id_foreign_fiscal_code(debtor_service_provider_token_a, random_foreign_fiscal_code):
+def test_get_activation_by_id_foreign_fiscal_code(debtor_service_provider_token_a, make_activation, random_foreign_fiscal_code):
 
-    res = activate(
-        debtor_service_provider_token_a,
-        random_foreign_fiscal_code,
-        secrets.debtor_service_provider.service_provider_id,
-    )
-    assert res.status_code == 201, f"Activation failed: {res.status_code} {res.text}"
-    activation_id = res.headers["Location"].rstrip("/").split("/")[-1]
+    activation_id, _ = make_activation(random_foreign_fiscal_code)
 
     res = get_activation_by_id(debtor_service_provider_token_a, activation_id)
     assert res.status_code == 200, f"Expected 200 but got {res.status_code}"
     body = res.json()
     assert body["id"] == activation_id
     assert body["payer"]["fiscalCode"] == random_foreign_fiscal_code
+    assert body["payer"]["rtpSpId"] == secrets.debtor_service_provider.service_provider_id
+
+    try:
+        datetime.strptime(body["effectiveActivationDate"], "%Y-%m-%dT%H:%M:%S.%f")
+    except ValueError:
+        assert False, "Invalid date format"
 
 
 @allure.epic("Debtor Activation")
@@ -91,21 +91,21 @@ def test_get_activation_by_id_foreign_fiscal_code(debtor_service_provider_token_
 @pytest.mark.auth
 @pytest.mark.activation
 @pytest.mark.happy_path
-def test_get_activation_by_id_vat_number(debtor_service_provider_token_a, random_vat_number):
+def test_get_activation_by_id_vat_number(debtor_service_provider_token_a, make_activation, random_vat_number):
 
-    res = activate(
-        debtor_service_provider_token_a,
-        random_vat_number,
-        secrets.debtor_service_provider.service_provider_id,
-    )
-    assert res.status_code == 201, f"Activation failed: {res.status_code} {res.text}"
-    activation_id = res.headers["Location"].rstrip("/").split("/")[-1]
+    activation_id, _ = make_activation(random_vat_number)
 
     res = get_activation_by_id(debtor_service_provider_token_a, activation_id)
     assert res.status_code == 200, f"Expected 200 but got {res.status_code}"
     body = res.json()
     assert body["id"] == activation_id
     assert body["payer"]["fiscalCode"] == random_vat_number
+    assert body["payer"]["rtpSpId"] == secrets.debtor_service_provider.service_provider_id
+
+    try:
+        datetime.strptime(body["effectiveActivationDate"], "%Y-%m-%dT%H:%M:%S.%f")
+    except ValueError:
+        assert False, "Invalid date format"
 
 
 @allure.epic("Debtor Activation")

--- a/functional-tests/tests/conftest.py
+++ b/functional-tests/tests/conftest.py
@@ -9,7 +9,7 @@ from api.debtor_activation_api import activate
 from config.configuration import config, secrets
 from utils.cryptography_utils import pfx_to_pem
 from utils.extract_next_activation_id import extract_next_activation_id
-from utils.fiscal_code_utils import fake_fc, fake_omocodia_fc
+from utils.fiscal_code_utils import fake_fc, fake_fc_foreign, fake_omocodia_fc
 from utils.log_sanitizer_helper import sanitize_bearer_token
 
 # ============================================================
@@ -198,6 +198,12 @@ def random_fiscal_code() -> str:
 def random_omocodia_fiscal_code() -> str:
     """Generate a random fiscal code with omocodia substitution (random level 1-7)."""
     return fake_omocodia_fc()
+
+
+@pytest.fixture
+def random_foreign_fiscal_code() -> str:
+    """Generate a random fiscal code for a foreign person (country code Z + 3 digits)."""
+    return fake_fc_foreign()
 
 
 @pytest.fixture

--- a/functional-tests/tests/conftest.py
+++ b/functional-tests/tests/conftest.py
@@ -158,14 +158,15 @@ def pagopa_service_providers_registry_token() -> str:
 @pytest.fixture
 def make_activation(
     debtor_service_provider_token_a: str,
-) -> Callable[[], tuple[str, str]]:
+) -> Callable[[str | None], tuple[str, str]]:
     """
     Factory fixture:
     creates a debtor activation and returns (activation_id, debtor_fc).
+    Accepts an optional fiscal_code; if omitted a random standard one is generated.
     """
 
-    def _create() -> tuple[str, str]:
-        debtor_fc: str = fake_fc()
+    def _create(fiscal_code: str | None = None) -> tuple[str, str]:
+        debtor_fc: str = fiscal_code if fiscal_code is not None else fake_fc()
         res = activate(
             debtor_service_provider_token_a,
             debtor_fc,

--- a/functional-tests/tests/conftest.py
+++ b/functional-tests/tests/conftest.py
@@ -9,7 +9,7 @@ from api.debtor_activation_api import activate
 from config.configuration import config, secrets
 from utils.cryptography_utils import pfx_to_pem
 from utils.extract_next_activation_id import extract_next_activation_id
-from utils.fiscal_code_utils import fake_fc
+from utils.fiscal_code_utils import fake_fc, fake_omocodia_fc
 from utils.log_sanitizer_helper import sanitize_bearer_token
 
 # ============================================================
@@ -192,6 +192,12 @@ def next_cursor() -> Callable[[str], str | None]:
 def random_fiscal_code() -> str:
     """Generate a random fiscal code for tests that need a fresh debtor."""
     return fake_fc()
+
+
+@pytest.fixture
+def random_omocodia_fiscal_code() -> str:
+    """Generate a random fiscal code with omocodia substitution (random level 1-7)."""
+    return fake_omocodia_fc()
 
 
 @pytest.fixture

--- a/functional-tests/tests/conftest.py
+++ b/functional-tests/tests/conftest.py
@@ -9,7 +9,7 @@ from api.debtor_activation_api import activate
 from config.configuration import config, secrets
 from utils.cryptography_utils import pfx_to_pem
 from utils.extract_next_activation_id import extract_next_activation_id
-from utils.fiscal_code_utils import fake_fc, fake_fc_foreign, fake_omocodia_fc
+from utils.fiscal_code_utils import fake_fc, fake_fc_foreign, fake_omocodia_fc, fake_vat
 from utils.log_sanitizer_helper import sanitize_bearer_token
 
 # ============================================================
@@ -204,6 +204,12 @@ def random_omocodia_fiscal_code() -> str:
 def random_foreign_fiscal_code() -> str:
     """Generate a random fiscal code for a foreign person (country code Z + 3 digits)."""
     return fake_fc_foreign()
+
+
+@pytest.fixture
+def random_vat_number() -> str:
+    """Generate a random Italian VAT number (Partita IVA, 11 digits)."""
+    return fake_vat()
 
 
 @pytest.fixture

--- a/functional-tests/tests/process_messages_sender/test_RTP_process_sender.py
+++ b/functional-tests/tests/process_messages_sender/test_RTP_process_sender.py
@@ -22,3 +22,24 @@ def test_send_gpd_message_create(rtp_consumer_access_token, random_fiscal_code, 
     response = send_gpd_message(access_token=rtp_consumer_access_token, message_payload=message_payload)
 
     assert response.status_code == 200, f"Expected 200, got {response.status_code}. Response: {response.text}"
+
+
+@allure.epic("RTP GPD Message")
+@allure.feature("GPD Message API")
+@allure.story("Consumer sends RTP message to Sender")
+@allure.title("A CREATE message with omocodia fiscal code is successfully sent through GPD message API")
+@allure.tag("functional", "happy_path", "gpd_message", "rtp_send", "omocodia")
+@pytest.mark.send
+@pytest.mark.happy_path
+def test_send_gpd_message_create_omocodia_fiscal_code(
+    rtp_consumer_access_token, random_omocodia_fiscal_code, activate_payer
+):
+    """Test sending a CREATE operation message with an omocodia fiscal code via GPD message API"""
+
+    activate_payer(random_omocodia_fiscal_code)
+
+    message_payload = generate_gpd_message_payload(random_omocodia_fiscal_code, "CREATE")
+
+    response = send_gpd_message(access_token=rtp_consumer_access_token, message_payload=message_payload)
+
+    assert response.status_code == 200, f"Expected 200, got {response.status_code}. Response: {response.text}"

--- a/functional-tests/tests/process_messages_sender/test_RTP_process_sender.py
+++ b/functional-tests/tests/process_messages_sender/test_RTP_process_sender.py
@@ -43,3 +43,24 @@ def test_send_gpd_message_create_omocodia_fiscal_code(
     response = send_gpd_message(access_token=rtp_consumer_access_token, message_payload=message_payload)
 
     assert response.status_code == 200, f"Expected 200, got {response.status_code}. Response: {response.text}"
+
+
+@allure.epic("RTP GPD Message")
+@allure.feature("GPD Message API")
+@allure.story("Consumer sends RTP message to Sender")
+@allure.title("A CREATE message with foreign fiscal code is successfully sent through GPD message API")
+@allure.tag("functional", "happy_path", "gpd_message", "rtp_send", "foreign")
+@pytest.mark.send
+@pytest.mark.happy_path
+def test_send_gpd_message_create_foreign_fiscal_code(
+    rtp_consumer_access_token, random_foreign_fiscal_code, activate_payer
+):
+    """Test sending a CREATE operation message with a foreign fiscal code via GPD message API"""
+
+    activate_payer(random_foreign_fiscal_code)
+
+    message_payload = generate_gpd_message_payload(random_foreign_fiscal_code, "CREATE")
+
+    response = send_gpd_message(access_token=rtp_consumer_access_token, message_payload=message_payload)
+
+    assert response.status_code == 200, f"Expected 200, got {response.status_code}. Response: {response.text}"

--- a/functional-tests/tests/process_messages_sender/test_RTP_process_sender.py
+++ b/functional-tests/tests/process_messages_sender/test_RTP_process_sender.py
@@ -73,9 +73,7 @@ def test_send_gpd_message_create_foreign_fiscal_code(
 @allure.tag("functional", "happy_path", "gpd_message", "rtp_send", "vat")
 @pytest.mark.send
 @pytest.mark.happy_path
-def test_send_gpd_message_create_vat_number(
-    rtp_consumer_access_token, random_vat_number, activate_payer
-):
+def test_send_gpd_message_create_vat_number(rtp_consumer_access_token, random_vat_number, activate_payer):
     """Test sending a CREATE operation message with an Italian VAT number via GPD message API"""
 
     activate_payer(random_vat_number)

--- a/functional-tests/tests/process_messages_sender/test_RTP_process_sender.py
+++ b/functional-tests/tests/process_messages_sender/test_RTP_process_sender.py
@@ -64,3 +64,24 @@ def test_send_gpd_message_create_foreign_fiscal_code(
     response = send_gpd_message(access_token=rtp_consumer_access_token, message_payload=message_payload)
 
     assert response.status_code == 200, f"Expected 200, got {response.status_code}. Response: {response.text}"
+
+
+@allure.epic("RTP GPD Message")
+@allure.feature("GPD Message API")
+@allure.story("Consumer sends RTP message to Sender")
+@allure.title("A CREATE message with VAT number (Partita IVA) is successfully sent through GPD message API")
+@allure.tag("functional", "happy_path", "gpd_message", "rtp_send", "vat")
+@pytest.mark.send
+@pytest.mark.happy_path
+def test_send_gpd_message_create_vat_number(
+    rtp_consumer_access_token, random_vat_number, activate_payer
+):
+    """Test sending a CREATE operation message with an Italian VAT number via GPD message API"""
+
+    activate_payer(random_vat_number)
+
+    message_payload = generate_gpd_message_payload(random_vat_number, "CREATE")
+
+    response = send_gpd_message(access_token=rtp_consumer_access_token, message_payload=message_payload)
+
+    assert response.status_code == 200, f"Expected 200, got {response.status_code}. Response: {response.text}"

--- a/out/production/rtp-platform-qa/utils/fiscal_code_utils.py
+++ b/out/production/rtp-platform-qa/utils/fiscal_code_utils.py
@@ -112,8 +112,7 @@ def fake_fc_foreign(
         country_code = _random_foreign_code()
 
     base = fake_fc(age=age, custom_month=custom_month, custom_day=custom_day, sex=sex)
-    cf = list(base[:11] + country_code)
-    return "".join(cf) + _cf_checksum(cf)
+    return f"{base[:11]}{country_code}{base[15]}"
 
 
 def fake_vat() -> str:

--- a/utils/fiscal_code_utils.py
+++ b/utils/fiscal_code_utils.py
@@ -6,21 +6,57 @@ from faker import Faker
 fake = Faker("it_IT")
 
 _FOREIGN_CODE_RANGES = [
-    (100, 156), (200, 259), (300, 368), (400, 404),
-    (500, 524), (600, 614), (700, 735), (800, 802), (900, 906),
+    (100, 156),
+    (200, 259),
+    (300, 368),
+    (400, 404),
+    (500, 524),
+    (600, 614),
+    (700, 735),
+    (800, 802),
+    (900, 906),
 ]
 
 _OMOCODIA_POSITIONS = [14, 13, 12, 10, 9, 7, 6]
 _OMOCODIA_MAP = dict(zip("0123456789", "LMNPQRSTUV"))
 
 _CF_ODD_VALUES = {
-    '0': 1,  '1': 0,  '2': 5,  '3': 7,  '4': 9,
-    '5': 13, '6': 15, '7': 17, '8': 19, '9': 21,
-    'A': 1,  'B': 0,  'C': 5,  'D': 7,  'E': 9,
-    'F': 13, 'G': 15, 'H': 17, 'I': 19, 'J': 21,
-    'K': 2,  'L': 4,  'M': 18, 'N': 20, 'O': 11,
-    'P': 3,  'Q': 6,  'R': 8,  'S': 12, 'T': 14,
-    'U': 16, 'V': 10, 'W': 22, 'X': 25, 'Y': 24, 'Z': 23,
+    "0": 1,
+    "1": 0,
+    "2": 5,
+    "3": 7,
+    "4": 9,
+    "5": 13,
+    "6": 15,
+    "7": 17,
+    "8": 19,
+    "9": 21,
+    "A": 1,
+    "B": 0,
+    "C": 5,
+    "D": 7,
+    "E": 9,
+    "F": 13,
+    "G": 15,
+    "H": 17,
+    "I": 19,
+    "J": 21,
+    "K": 2,
+    "L": 4,
+    "M": 18,
+    "N": 20,
+    "O": 11,
+    "P": 3,
+    "Q": 6,
+    "R": 8,
+    "S": 12,
+    "T": 14,
+    "U": 16,
+    "V": 10,
+    "W": 22,
+    "X": 25,
+    "Y": 24,
+    "Z": 23,
 }
 
 
@@ -172,6 +208,7 @@ def _vat_check_digit(digits: list) -> int:
     even_sum = sum(d * 2 if d * 2 < 10 else d * 2 - 9 for d in (digits[i] for i in range(1, 10, 2)))
     return (10 - (odd_sum + even_sum) % 10) % 10
 
+
 def _cf_checksum(cf: list) -> str:
     """Compute the control character for an Italian fiscal code.
 
@@ -182,7 +219,7 @@ def _cf_checksum(cf: list) -> str:
         The control character (A–Z).
     """
     total = sum(
-        _CF_ODD_VALUES[c] if i % 2 == 0 else (ord(c) - ord('A') if c.isalpha() else int(c))
+        _CF_ODD_VALUES[c] if i % 2 == 0 else (ord(c) - ord("A") if c.isalpha() else int(c))
         for i, c in enumerate(cf[:15])
     )
-    return chr(ord('A') + total % 26)
+    return chr(ord("A") + total % 26)

--- a/utils/fiscal_code_utils.py
+++ b/utils/fiscal_code_utils.py
@@ -5,6 +5,17 @@ from faker import Faker
 
 fake = Faker("it_IT")
 
+# Valid numeric ranges for Italian foreign cadastral codes (codici catastali esteri).
+# Each tuple is (lo, hi) inclusive; the full code is "Z" + the 3-digit number.
+_FOREIGN_CODE_RANGES = [
+    (100, 156), (200, 259), (300, 368), (400, 404),
+    (500, 524), (600, 614), (700, 735), (800, 802), (900, 906),
+]
+
+# Omocodia: digit positions (0-indexed) that can be substituted, ordered right-to-left
+_OMOCODIA_POSITIONS = [14, 13, 12, 10, 9, 7, 6]
+_OMOCODIA_MAP = dict(zip("0123456789", "LMNPQRSTUV"))
+
 
 def fake_fc(age: int = None, custom_month: int = None, custom_day: int = None, sex: str = None) -> str:
     """Generate a fake fiscal code with customizable parameters.
@@ -47,11 +58,6 @@ def fake_fc(age: int = None, custom_month: int = None, custom_day: int = None, s
     return f"{surname}{name}{year}{month_letter}{day}{municipality}{checksum}"
 
 
-# Omocodia: digit positions (0-indexed) that can be substituted, ordered right-to-left
-_OMOCODIA_POSITIONS = [14, 13, 12, 10, 9, 7, 6]
-_OMOCODIA_MAP = dict(zip("0123456789", "LMNPQRSTUV"))
-
-
 def fake_omocodia_fc(level: int = None) -> str:
     """Generate a fake fiscal code with omocodia substitution.
 
@@ -71,6 +77,36 @@ def fake_omocodia_fc(level: int = None) -> str:
     return "".join(cf)
 
 
+def fake_fc_foreign(
+    age: int = None,
+    custom_month: int = None,
+    custom_day: int = None,
+    sex: str = None,
+    country_code: str = None,
+) -> str:
+    """Generate a fake Italian fiscal code for a person born in a foreign country.
+
+    The municipality code (positions 11–14) is replaced with a foreign country
+    cadastral code (codice catastale estero), which always starts with 'Z'.
+
+    Args:
+        age: Age of the person.
+        custom_month: Birth month (1–12).
+        custom_day: Birth day (1–31).
+        sex: Sex of the person ('M' or 'F').
+        country_code: A specific foreign country cadastral code (e.g. 'Z110' for Germany).
+                      If omitted, a random code is chosen from the valid ranges.
+
+    Returns:
+        A fake fiscal code string with a foreign country cadastral code.
+    """
+    if country_code is None:
+        country_code = _random_foreign_code()
+
+    base = fake_fc(age=age, custom_month=custom_month, custom_day=custom_day, sex=sex)
+    return f"{base[:11]}{country_code}{base[15]}"
+
+
 def month_number_to_fc_letter(month_num: int) -> str:
     """Convert month number to fiscal code letter.
 
@@ -85,3 +121,13 @@ def month_number_to_fc_letter(month_num: int) -> str:
         return months[int(month_num) - 1]
     else:
         return "A"
+
+def _random_foreign_code() -> str:
+    """Pick a random foreign country cadastral code from the valid ranges.
+
+    Returns:
+        A 4-character string starting with 'Z' followed by a 3-digit number
+        within one of the valid ranges defined in _FOREIGN_CODE_RANGES.
+    """
+    lo, hi = random.choice(_FOREIGN_CODE_RANGES)
+    return f"Z{random.randint(lo, hi)}"

--- a/utils/fiscal_code_utils.py
+++ b/utils/fiscal_code_utils.py
@@ -1,3 +1,4 @@
+import random
 from datetime import datetime, timedelta
 
 from faker import Faker
@@ -44,6 +45,30 @@ def fake_fc(age: int = None, custom_month: int = None, custom_day: int = None, s
         day = fake_cf[9:11]
 
     return f"{surname}{name}{year}{month_letter}{day}{municipality}{checksum}"
+
+
+# Omocodia: digit positions (0-indexed) that can be substituted, ordered right-to-left
+_OMOCODIA_POSITIONS = [14, 13, 12, 10, 9, 7, 6]
+_OMOCODIA_MAP = dict(zip("0123456789", "LMNPQRSTUV"))
+
+
+def fake_omocodia_fc(level: int = None) -> str:
+    """Generate a fake fiscal code with omocodia substitution.
+
+    Args:
+        level: Number of digit positions to substitute (1-7). Defaults to random.
+
+    Returns:
+        A fiscal code string with omocodia substitution applied.
+    """
+    if level is None:
+        level = random.randint(1, 7)
+    level = max(1, min(level, 7))
+
+    cf = list(fake_fc())
+    for pos in _OMOCODIA_POSITIONS[:level]:
+        cf[pos] = _OMOCODIA_MAP[cf[pos]]
+    return "".join(cf)
 
 
 def month_number_to_fc_letter(month_num: int) -> str:

--- a/utils/fiscal_code_utils.py
+++ b/utils/fiscal_code_utils.py
@@ -22,6 +22,7 @@ def fake_fc(age: int = None, custom_month: int = None, custom_day: int = None, s
     surname = fake_cf[:3]
     name = fake_cf[3:6]
     year = fake_cf[6:8]
+    municipality = fake_cf[11:15]
     checksum = fake_cf[15]
 
     if age is not None:
@@ -35,14 +36,14 @@ def fake_fc(age: int = None, custom_month: int = None, custom_day: int = None, s
     if custom_day is not None and 1 <= custom_day <= 31:
         day = str(custom_day).zfill(2)
         if sex == "F":
-            day = int(day) + 40
+            day = str(int(day) + 40)
         else:
             if int(day) > 31:
                 day = str(int(day) - 40).zfill(2)
     else:
         day = fake_cf[9:11]
 
-    return f"{surname}{name}{year}{month_letter}{day}X000{checksum}"
+    return f"{surname}{name}{year}{month_letter}{day}{municipality}{checksum}"
 
 
 def month_number_to_fc_letter(month_num: int) -> str:

--- a/utils/fiscal_code_utils.py
+++ b/utils/fiscal_code_utils.py
@@ -107,6 +107,22 @@ def fake_fc_foreign(
     return f"{base[:11]}{country_code}{base[15]}"
 
 
+def fake_vat() -> str:
+    """Generate a fake Italian VAT number (Partita IVA).
+
+    A Partita IVA is an 11-digit string: 7 random digits, a 3-digit province
+    code (001–100), and a Luhn-like check digit.
+
+    Returns:
+        An 11-digit string representing a valid Italian VAT number.
+    """
+    digits = [random.randint(0, 9) for _ in range(7)]
+    province = random.randint(1, 100)
+    digits += [province // 100, (province // 10) % 10, province % 10]
+    digits.append(_vat_check_digit(digits))
+    return "".join(map(str, digits))
+
+
 def month_number_to_fc_letter(month_num: int) -> str:
     """Convert month number to fiscal code letter.
 
@@ -122,6 +138,7 @@ def month_number_to_fc_letter(month_num: int) -> str:
     else:
         return "A"
 
+
 def _random_foreign_code() -> str:
     """Pick a random foreign country cadastral code from the valid ranges.
 
@@ -131,3 +148,17 @@ def _random_foreign_code() -> str:
     """
     lo, hi = random.choice(_FOREIGN_CODE_RANGES)
     return f"Z{random.randint(lo, hi)}"
+
+
+def _vat_check_digit(digits: list) -> int:
+    """Compute the check digit for an Italian VAT number (Partita IVA).
+
+    Args:
+        digits: The first 10 digits of the VAT number as a list of ints.
+
+    Returns:
+        The check digit (0–9).
+    """
+    odd_sum = sum(digits[i] for i in range(0, 10, 2))
+    even_sum = sum(d * 2 if d * 2 < 10 else d * 2 - 9 for d in (digits[i] for i in range(1, 10, 2)))
+    return (10 - (odd_sum + even_sum) % 10) % 10


### PR DESCRIPTION
### Description

This PR extends the test suite to cover three additional payer identifier variants that are valid in the Italian tax system but were previously not exercised: **omocodia** codes (where one or more digit positions are replaced by letters according to a fixed substitution table), **foreign-country** codes (where the municipality field is replaced by a cadastral code starting with `Z`, assigned to a foreign state), and **Partita IVA** numbers (11-digit VAT numbers used by sole traders and legal entities).

All three variants are accepted by the debtor activation API and must be handled correctly end-to-end.

### List of changes

- **`utils/fiscal_code_utils.py`**
  - Added `fake_omocodia_fc(level)`: generates a fiscal code with omocodia substitution applied to 1–7 digit positions (random level by default).
  - Added `fake_fc_foreign(...)`: generates a fiscal code whose municipality field is replaced by a foreign cadastral code (`Z` + 3-digit number). The numeric part is drawn at random from the official valid ranges; a specific code can be passed via `country_code`.
  - Added `fake_vat()`: generates a valid Italian VAT number (Partita IVA) — 7 random digits, a province code (001–100), and a Luhn-like check digit.

- **`functional-tests/tests/conftest.py`**
  - Added `random_omocodia_fiscal_code` fixture backed by `fake_omocodia_fc`.
  - Added `random_foreign_fiscal_code` fixture backed by `fake_fc_foreign`.
  - Added `random_vat_number` fixture backed by `fake_vat`.
  - Updated import to include `fake_fc_foreign`, `fake_omocodia_fc`, and `fake_vat`.

- **`functional-tests/tests/activation/test_debtor_activation_create.py`**
  - Added `test_activate_debtor_with_omocodia_fiscal_code`: verifies that a debtor with an omocodia fiscal code can be activated (HTTP 201) and retrieved (HTTP 200).
  - Added `test_activate_debtor_with_foreign_fiscal_code`: verifies the same flow for a foreign-country fiscal code.
  - Added `test_activate_debtor_with_vat_number`: verifies the same flow for a Partita IVA.

- **`functional-tests/tests/activation/test_debtor_activation_get.py`**
  - Added `test_get_activation_by_id_omocodia_fiscal_code`: activates a debtor with omocodia code, then retrieves the activation by ID and asserts the fiscal code is preserved.
  - Added `test_get_activation_by_id_foreign_fiscal_code`: same flow for a foreign-country fiscal code.
  - Added `test_get_activation_by_id_vat_number`: same flow for a Partita IVA.

- **`functional-tests/tests/process_messages_sender/test_RTP_process_sender.py`**
  - Added equivalent omocodia, foreign fiscal code, and Partita IVA test cases for the RTP process sender flow.

### Motivation and context

The debtor activation service must accept any syntactically valid Italian tax identifier, including omocodia variants (issued when a standard code would conflict with an existing one), codes assigned to foreign-born citizens, and Partita IVA numbers used by sole traders and legal entities. These cases had no test coverage, leaving a gap that could hide regressions in identifier validation logic.

### Aggregation level

- [ ] Test case
- [x] Test suite

### Test type

- [x] Functional test
- [ ] Bdd test
- [ ] Performance
- [ ] End to end

### Type of changes

- [x] Add new test case/suite
- [x] Modify existing test case/suite

### Test Results

- [x] Success
- [ ] Failure
- [ ] Poor performance
- [ ] Good performance

### Did you update secrets accordingly?

- [ ] Yes
  - [ ] `.secrets_template.yaml`
  - [ ] Pipelines' secure file
  - [ ] Confluence
- [x] Not needed
- [ ] No (_please provide further information_)

### Did you update dependencies accordingly?

- [ ] Yes (which requirements.txt did you update?)
- [x] Not needed

### Other information