### PR TITLE
feat: [SRTP-1980] add GET /activations/payer/status endpoint and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ pytest functional-tests/tests/ -q
 
 | Directory | Coverage |
 |-----------|----------|
-| `activation/` | Debtor activation create, get, list, deactivation, security |
+| `activation/` | Debtor activation create, get, list, deactivation, payer status (GET /activations/payer/status), security |
 | `auth/` | OAuth2 / Keycloak token retrieval and bearer token format |
 | `availability/` | Service availability checks |
 | `callbacks/` | RTP callback scenarios DS-04, DS-05, DS-08, DS-12N, DS-12P |

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ pytest functional-tests/tests/ -q
 
 | Directory | Coverage |
 |-----------|----------|
-| `activation/` | Debtor activation create, get, list, deactivation, payer status (GET /activations/payer/status), security |
+| `activation/` | Debtor activation create, get, list, deactivation, payer status (GET /activations/payer/{payerId}/status), security |
 | `auth/` | OAuth2 / Keycloak token retrieval and bearer token format |
 | `availability/` | Service availability checks |
 | `callbacks/` | RTP callback scenarios DS-04, DS-05, DS-08, DS-12N, DS-12P |

--- a/api/debtor_activation_api.py
+++ b/api/debtor_activation_api.py
@@ -3,7 +3,13 @@ import uuid
 import requests
 
 from api.utils.api_version import ACTIVATION_VERSION
-from api.utils.endpoints import ACTIVATION_BY_ID_URL, ACTIVATION_LIST_URL, ACTIVATION_URL, ACTIVATION_URL_DEV
+from api.utils.endpoints import (
+    ACTIVATION_BY_ID_URL,
+    ACTIVATION_LIST_URL,
+    ACTIVATION_PAYER_STATUS_URL,
+    ACTIVATION_URL,
+    ACTIVATION_URL_DEV,
+)
 from api.utils.http_utils import HTTP_TIMEOUT
 
 
@@ -55,6 +61,45 @@ def get_activation_by_id(access_token: str, activation_id: str):
     return requests.get(
         url=ACTIVATION_BY_ID_URL.format(activationId=activation_id),
         headers={"Authorization": f"{access_token}", "Version": ACTIVATION_VERSION, "RequestId": str(uuid.uuid4())},
+        timeout=HTTP_TIMEOUT,
+    )
+
+
+def get_activation_status_by_fiscal_code(access_token: str, payer_fiscal_code: str):
+    """API to check whether a payer is active, returning minimal yes/no without PII.
+
+    The response is deliberately indistinguishable between "not found" and
+    "active under a different Service Provider" to avoid information disclosure.
+
+    :returns: the response of the call.
+    :rtype: requests.Response
+    """
+    return requests.get(
+        url=ACTIVATION_PAYER_STATUS_URL,
+        headers={
+            "Authorization": f"{access_token}",
+            "Version": ACTIVATION_VERSION,
+            "RequestId": str(uuid.uuid4()),
+            "PayerId": payer_fiscal_code,
+        },
+        timeout=HTTP_TIMEOUT,
+    )
+
+
+def get_activation_status_without_payer_id(access_token: str):
+    """API call to the payer status endpoint omitting the PayerId header.
+    Used to test the 400 error response when the required header is missing.
+
+    :returns: the response of the call.
+    :rtype: requests.Response
+    """
+    return requests.get(
+        url=ACTIVATION_PAYER_STATUS_URL,
+        headers={
+            "Authorization": f"{access_token}",
+            "Version": ACTIVATION_VERSION,
+            "RequestId": str(uuid.uuid4()),
+        },
         timeout=HTTP_TIMEOUT,
     )
 

--- a/api/debtor_activation_api.py
+++ b/api/debtor_activation_api.py
@@ -75,26 +75,7 @@ def get_activation_status_by_fiscal_code(access_token: str, payer_fiscal_code: s
     :rtype: requests.Response
     """
     return requests.get(
-        url=ACTIVATION_PAYER_STATUS_URL,
-        headers={
-            "Authorization": f"{access_token}",
-            "Version": ACTIVATION_VERSION,
-            "RequestId": str(uuid.uuid4()),
-            "PayerId": payer_fiscal_code,
-        },
-        timeout=HTTP_TIMEOUT,
-    )
-
-
-def get_activation_status_without_payer_id(access_token: str):
-    """API call to the payer status endpoint omitting the PayerId header.
-    Used to test the 400 error response when the required header is missing.
-
-    :returns: the response of the call.
-    :rtype: requests.Response
-    """
-    return requests.get(
-        url=ACTIVATION_PAYER_STATUS_URL,
+        url=ACTIVATION_PAYER_STATUS_URL.format(payerId=payer_fiscal_code),
         headers={
             "Authorization": f"{access_token}",
             "Version": ACTIVATION_VERSION,

--- a/api/utils/endpoints.py
+++ b/api/utils/endpoints.py
@@ -32,6 +32,7 @@ PRODUCER_GPD_MESSAGE_URL = config.producer_gpd_message_base_url + config.send_gp
 SEND_RTP_URL = config.rtp_creation_base_url_path + config.send_rtp_path
 SERVICE_PROVIDER_MOCK_URL = config.mock_service_provider_url
 SERVICE_PROVIDERS_URL = config.rtp_creation_base_url_path + config.service_providers_registry
+ACTIVATION_PAYER_STATUS_URL = config.activation_base_url_path + config.activation_payer_status_path
 TAKEOVER_URL = config.activation_base_url_path + config.activation_takeover
 TAKEOVER_NOTIFICATION_URL = config.takeover_notification_url
 LANDING_PAGE_URL = config.landing_page_path

--- a/config.yaml
+++ b/config.yaml
@@ -91,6 +91,7 @@ iccrea_send_url: 'https://r5i-svil.api.gbi.bcc.it/pagopa4/pagopa-broker-api/pago
 # ACTIVATION LIST AND DETAILS
 # ============================
 activation_list_path: "/activations"
+activation_payer_status_path: "/activations/payer/status"
 activation_takeover: "/activations/takeover"
 takeover_api_version: 'v1'
 activation_by_id_path: "/activations/{activationId}"

--- a/config.yaml
+++ b/config.yaml
@@ -91,7 +91,7 @@ iccrea_send_url: 'https://r5i-svil.api.gbi.bcc.it/pagopa4/pagopa-broker-api/pago
 # ACTIVATION LIST AND DETAILS
 # ============================
 activation_list_path: "/activations"
-activation_payer_status_path: "/activations/payer/status"
+activation_payer_status_path: "/activations/payer/{payerId}/status"
 activation_takeover: "/activations/takeover"
 takeover_api_version: 'v1'
 activation_by_id_path: "/activations/{activationId}"

--- a/functional-tests/tests/activation/test_debtor_activation_payer_status.py
+++ b/functional-tests/tests/activation/test_debtor_activation_payer_status.py
@@ -1,7 +1,8 @@
-"""Tests for the GET /activations/payer/status endpoint.
+"""Tests for the GET /activations/payer/{payerId}/status endpoint.
 
 This endpoint returns a minimal yes/no response indicating whether a payer (identified
 by fiscal code or VAT number) is currently active in the RTP system.
+The ``payerId`` is passed as a **path parameter**.
 
 Privacy rule: the response is deliberately indistinguishable between "not found" and
 "active under a different Service Provider" — both cases return ``{ "isActive": false }``
@@ -12,7 +13,7 @@ Authorization roles:
   the ``sub`` claim of the presented JWT.
 - ``read_rtp_all``: reads activations for any Service Provider (admin-level visibility).
 
-The ``_INVALID_PAYER_IDS`` constant drives the parametrized 400 suite.
+The ``INVALID_PAYER_IDS`` constant (from ``tests.payer_id_data``) drives the parametrized 400 suite.
 It mirrors the ``invalidFiscalCodes`` data source in ``ActivationAPIControllerImplTest.java``
 and is extended with structural edge cases from the Italian CF/PIVA specification:
 
@@ -27,38 +28,15 @@ and is extended with structural edge cases from the Italian CF/PIVA specificatio
 - **EU VAT prefix**: ``IT`` + 11 digits → 13 chars → length error (common client mistake).
 - **Checksum probe**: syntactically valid CF with wrong control character.  This case acts
   as a TDD sentinel: it stays red until the backend enforces checksum validation.
+- **Empty string**: empty path segment → 400 (or 404 depending on routing).
 """
 
 import allure
 import pytest
 
-from api.debtor_activation_api import get_activation_status_by_fiscal_code, get_activation_status_without_payer_id
+from api.debtor_activation_api import get_activation_status_by_fiscal_code
 from api.debtor_deactivation_api import deactivate
-
-_INVALID_PAYER_IDS = [
-    ("too_short_fiscal_code", "XCGCHS98M13F16"),
-    ("too_long_fiscal_code", "XCGCHS98M13F166EXX"),
-    ("vat_number_10_digits", "1234567890"),
-    ("vat_number_12_digits", "123456789012"),
-    ("lowercase_fiscal_code", "xcgchs98m13f166e"),
-    ("mixed_case_fiscal_code", "XcGCHS98M13F166E"),
-    ("invalid_month_code_F", "XCGCHS98F13F166E"),
-    ("invalid_month_code_G", "XCGCHS98G13F166E"),
-    ("invalid_month_code_U", "XCGCHS98U13F166E"),
-    ("invalid_birth_day_00", "XCGCHS98M00F166E"),
-    ("invalid_birth_day_32_male", "XCGCHS98M32F166E"),
-    ("invalid_birth_day_40_dead_zone", "XCGCHS98M40F166E"),
-    ("invalid_birth_day_72_female", "XCGCHS98M72F166E"),
-    ("non_alphanumeric_character", "XCGCHS98M13F166!"),
-    ("space_in_fiscal_code", "XCGCHS98M13 F66E"),
-    ("cf_with_leading_whitespace", " XCGCHS98M13F166E"),
-    ("cf_with_trailing_whitespace", "XCGCHS98M13F166E "),
-    ("non_numeric_vat_like", "ABCDEFGHIJK"),
-    ("all_zeros_10_digits", "0000000000"),
-    ("vat_with_eu_it_prefix", "IT12345678903"),
-    ("cf_wrong_checksum", "RSSMRA85T10A562T"),
-    ("empty_string", ""),
-]
+from utils.dataset_payer_id_invalid import INVALID_PAYER_IDS
 
 
 @allure.epic("Debtor Activation")
@@ -252,28 +230,15 @@ def test_get_activation_status_unauthorized():
 
 
 @allure.epic("Debtor Activation")
-@allure.feature("Payer Status")
-@allure.story("Get Activation Status by Fiscal Code")
-@allure.title("Querying activation status without the PayerId header returns 400")
-@allure.tag("functional", "unhappy_path", "activation", "payer_status")
-@pytest.mark.activation
-@pytest.mark.unhappy_path
-def test_get_activation_status_missing_payer_id_header(debtor_service_provider_token_a):
-    """Request without the required ``PayerId`` header → must return 400."""
-    res = get_activation_status_without_payer_id(debtor_service_provider_token_a)
-    assert res.status_code == 400, f"Expected 400 but got {res.status_code}: {res.text}"
-
-
 @allure.epic("Debtor Activation")
 @allure.feature("Payer Status")
 @allure.story("Get Activation Status by Fiscal Code")
-@allure.title("Querying activation status with an invalid payerId format returns 400")
-@allure.tag("functional", "unhappy_path", "activation", "payer_status")
+@allure.title("Querying activation status with an invalid payerId format returns 400")@allure.tag("functional", "unhappy_path", "activation", "payer_status")
 @pytest.mark.activation
 @pytest.mark.unhappy_path
-@pytest.mark.parametrize("description,invalid_payer_id", _INVALID_PAYER_IDS)
+@pytest.mark.parametrize("description,invalid_payer_id", INVALID_PAYER_IDS)
 def test_get_activation_status_invalid_payer_id_format(debtor_service_provider_token_a, description, invalid_payer_id):
-    """Each entry in ``_INVALID_PAYER_IDS`` must be rejected with 400.
+    """Each entry in ``INVALID_PAYER_IDS`` must be rejected with 400.
 
     The ``description`` parameter appears in pytest output to identify which
     case failed without having to inspect the raw value.

--- a/functional-tests/tests/activation/test_debtor_activation_payer_status.py
+++ b/functional-tests/tests/activation/test_debtor_activation_payer_status.py
@@ -74,6 +74,8 @@ def test_get_activation_status_active_payer(debtor_service_provider_token_a, mak
     res = get_activation_status_by_fiscal_code(debtor_service_provider_token_a, debtor_fc)
     assert res.status_code == 200, f"Expected 200 but got {res.status_code}: {res.text}"
     assert res.json()["isActive"] is True, f"Expected isActive=true but got: {res.json()}"
+
+
 @allure.tag("functional", "happy_path", "activation", "payer_status")
 @pytest.mark.activation
 @pytest.mark.happy_path
@@ -82,6 +84,8 @@ def test_get_activation_status_not_active_payer(debtor_service_provider_token_a,
     res = get_activation_status_by_fiscal_code(debtor_service_provider_token_a, random_fiscal_code)
     assert res.status_code == 200, f"Expected 200 but got {res.status_code}: {res.text}"
     assert res.json()["isActive"] is False, f"Expected isActive=false but got: {res.json()}"
+
+
 @allure.feature("Payer Status")
 @allure.story("Get Activation Status by Fiscal Code")
 @allure.title("A payer active on a different Service Provider returns isActive false (privacy)")
@@ -124,15 +128,15 @@ def test_get_activation_status_read_rtp_all_role_own_service_provider(
 
     res = get_activation_status_by_fiscal_code(sp_activations_read_all_token, debtor_fc)
     assert res.status_code == 200, f"Expected 200 but got {res.status_code}: {res.text}"
-    assert res.json()["isActive"] is True, (
-        f"Expected isActive=true with read_rtp_all role but got: {res.json()}"
-    )
+    assert res.json()["isActive"] is True, f"Expected isActive=true with read_rtp_all role but got: {res.json()}"
 
 
 @allure.epic("Debtor Activation")
 @allure.feature("Payer Status")
 @allure.story("Get Activation Status by Fiscal Code")
-@allure.title("read_rtp_all role returns isActive true while read_rtp_activations returns false for the same cross-SP payer")
+@allure.title(
+    "read_rtp_all role returns isActive true while read_rtp_activations returns false for the same cross-SP payer"
+)
 @allure.tag("functional", "happy_path", "activation", "payer_status", "rbac")
 @pytest.mark.activation
 @pytest.mark.happy_path
@@ -268,15 +272,11 @@ def test_get_activation_status_missing_payer_id_header(debtor_service_provider_t
 @pytest.mark.activation
 @pytest.mark.unhappy_path
 @pytest.mark.parametrize("description,invalid_payer_id", _INVALID_PAYER_IDS)
-def test_get_activation_status_invalid_payer_id_format(
-    debtor_service_provider_token_a, description, invalid_payer_id
-):
+def test_get_activation_status_invalid_payer_id_format(debtor_service_provider_token_a, description, invalid_payer_id):
     """Each entry in ``_INVALID_PAYER_IDS`` must be rejected with 400.
 
     The ``description`` parameter appears in pytest output to identify which
     case failed without having to inspect the raw value.
     """
     res = get_activation_status_by_fiscal_code(debtor_service_provider_token_a, invalid_payer_id)
-    assert res.status_code == 400, (
-        f"[{description}] Expected 400 but got {res.status_code}: {res.text}"
-    )
+    assert res.status_code == 400, f"[{description}] Expected 400 but got {res.status_code}: {res.text}"

--- a/functional-tests/tests/activation/test_debtor_activation_payer_status.py
+++ b/functional-tests/tests/activation/test_debtor_activation_payer_status.py
@@ -1,0 +1,282 @@
+"""Tests for the GET /activations/payer/status endpoint.
+
+This endpoint returns a minimal yes/no response indicating whether a payer (identified
+by fiscal code or VAT number) is currently active in the RTP system.
+
+Privacy rule: the response is deliberately indistinguishable between "not found" and
+"active under a different Service Provider" — both cases return ``{ "isActive": false }``
+— to avoid leaking cross-SP information to competitors.
+
+Authorization roles:
+- ``read_rtp_activations``: reads only activations whose ``serviceProviderDebtor`` matches
+  the ``sub`` claim of the presented JWT.
+- ``read_rtp_all``: reads activations for any Service Provider (admin-level visibility).
+
+The ``_INVALID_PAYER_IDS`` constant drives the parametrized 400 suite.
+It mirrors the ``invalidFiscalCodes`` data source in ``ActivationAPIControllerImplTest.java``
+and is extended with structural edge cases from the Italian CF/PIVA specification:
+
+- **Length boundaries**: too-short (14) and too-long (18) CFs; 10- and 12-digit VATs.
+- **Case**: lowercase and mixed-case CFs (only uppercase alphanumeric is valid).
+- **Month codes**: valid set is A B C D E H L M P R S T.  F and G (between valid E and H)
+  and U (outside range) are the most common off-by-one mistakes.
+- **Birth day**: male range 01–31, female range 41–71.  Day 00, 32, 40 (dead zone), and 72
+  are the relevant boundary violations.
+- **Special characters**: ``!``, embedded space, leading/trailing whitespace (17 chars → length
+  error), non-numeric VAT-like string, all-zeros (10 digits).
+- **EU VAT prefix**: ``IT`` + 11 digits → 13 chars → length error (common client mistake).
+- **Checksum probe**: syntactically valid CF with wrong control character.  This case acts
+  as a TDD sentinel: it stays red until the backend enforces checksum validation.
+"""
+
+import allure
+import pytest
+
+from api.debtor_activation_api import get_activation_status_by_fiscal_code, get_activation_status_without_payer_id
+from api.debtor_deactivation_api import deactivate
+
+_INVALID_PAYER_IDS = [
+    ("too_short_fiscal_code", "XCGCHS98M13F16"),
+    ("too_long_fiscal_code", "XCGCHS98M13F166EXX"),
+    ("vat_number_10_digits", "1234567890"),
+    ("vat_number_12_digits", "123456789012"),
+    ("lowercase_fiscal_code", "xcgchs98m13f166e"),
+    ("mixed_case_fiscal_code", "XcGCHS98M13F166E"),
+    ("invalid_month_code_F", "XCGCHS98F13F166E"),
+    ("invalid_month_code_G", "XCGCHS98G13F166E"),
+    ("invalid_month_code_U", "XCGCHS98U13F166E"),
+    ("invalid_birth_day_00", "XCGCHS98M00F166E"),
+    ("invalid_birth_day_32_male", "XCGCHS98M32F166E"),
+    ("invalid_birth_day_40_dead_zone", "XCGCHS98M40F166E"),
+    ("invalid_birth_day_72_female", "XCGCHS98M72F166E"),
+    ("non_alphanumeric_character", "XCGCHS98M13F166!"),
+    ("space_in_fiscal_code", "XCGCHS98M13 F66E"),
+    ("cf_with_leading_whitespace", " XCGCHS98M13F166E"),
+    ("cf_with_trailing_whitespace", "XCGCHS98M13F166E "),
+    ("non_numeric_vat_like", "ABCDEFGHIJK"),
+    ("all_zeros_10_digits", "0000000000"),
+    ("vat_with_eu_it_prefix", "IT12345678903"),
+    ("cf_wrong_checksum", "RSSMRA85T10A562T"),
+    ("empty_string", ""),
+]
+
+
+@allure.epic("Debtor Activation")
+@allure.feature("Payer Status")
+@allure.story("Get Activation Status by Fiscal Code")
+@allure.title("An active payer returns isActive true for the same Service Provider")
+@allure.tag("functional", "happy_path", "activation", "payer_status")
+@pytest.mark.activation
+@pytest.mark.happy_path
+def test_get_activation_status_active_payer(debtor_service_provider_token_a, make_activation):
+    """Payer activated under SP A queried by SP A → isActive must be true."""
+    _activation_id, debtor_fc = make_activation()
+    res = get_activation_status_by_fiscal_code(debtor_service_provider_token_a, debtor_fc)
+    assert res.status_code == 200, f"Expected 200 but got {res.status_code}: {res.text}"
+    assert res.json()["isActive"] is True, f"Expected isActive=true but got: {res.json()}"
+@allure.tag("functional", "happy_path", "activation", "payer_status")
+@pytest.mark.activation
+@pytest.mark.happy_path
+def test_get_activation_status_not_active_payer(debtor_service_provider_token_a, random_fiscal_code):
+    """Payer that has never been activated → isActive must be false."""
+    res = get_activation_status_by_fiscal_code(debtor_service_provider_token_a, random_fiscal_code)
+    assert res.status_code == 200, f"Expected 200 but got {res.status_code}: {res.text}"
+    assert res.json()["isActive"] is False, f"Expected isActive=false but got: {res.json()}"
+@allure.feature("Payer Status")
+@allure.story("Get Activation Status by Fiscal Code")
+@allure.title("A payer active on a different Service Provider returns isActive false (privacy)")
+@allure.tag("functional", "happy_path", "activation", "payer_status")
+@pytest.mark.activation
+@pytest.mark.happy_path
+def test_get_activation_status_active_payer_different_service_provider(
+    debtor_service_provider_token_a, debtor_service_provider_token_b, make_activation
+):
+    """
+    SP A activates the payer.
+    SP B queries the status → must get isActive=false to avoid disclosing
+    that the payer is registered under a competitor SP.
+    """
+    _activation_id, debtor_fc = make_activation()
+
+    res = get_activation_status_by_fiscal_code(debtor_service_provider_token_b, debtor_fc)
+    assert res.status_code == 200, f"Expected 200 but got {res.status_code}: {res.text}"
+    assert res.json()["isActive"] is False, (
+        f"Expected isActive=false for a different SP (privacy rule) but got: {res.json()}"
+    )
+
+
+@allure.epic("Debtor Activation")
+@allure.feature("Payer Status")
+@allure.story("Get Activation Status by Fiscal Code")
+@allure.title("read_rtp_all role returns isActive true for a payer on any Service Provider")
+@allure.tag("functional", "happy_path", "activation", "payer_status", "rbac")
+@pytest.mark.activation
+@pytest.mark.happy_path
+def test_get_activation_status_read_rtp_all_role_own_service_provider(
+    debtor_service_provider_token_a, sp_activations_read_all_token, make_activation
+):
+    """
+    Payer activated under SP A.
+    Token with read_rtp_all can read across all Service Providers:
+    the admin client sub does not match SP A, yet isActive must be true.
+    """
+    _activation_id, debtor_fc = make_activation()
+
+    res = get_activation_status_by_fiscal_code(sp_activations_read_all_token, debtor_fc)
+    assert res.status_code == 200, f"Expected 200 but got {res.status_code}: {res.text}"
+    assert res.json()["isActive"] is True, (
+        f"Expected isActive=true with read_rtp_all role but got: {res.json()}"
+    )
+
+
+@allure.epic("Debtor Activation")
+@allure.feature("Payer Status")
+@allure.story("Get Activation Status by Fiscal Code")
+@allure.title("read_rtp_all role returns isActive true while read_rtp_activations returns false for the same cross-SP payer")
+@allure.tag("functional", "happy_path", "activation", "payer_status", "rbac")
+@pytest.mark.activation
+@pytest.mark.happy_path
+def test_get_activation_status_role_comparison_cross_service_provider(
+    debtor_service_provider_token_b, sp_activations_read_all_token, make_activation
+):
+    """
+    Payer activated under SP A.
+    - SP B (read_rtp_activations): isActive must be false — privacy rule hides cross-SP activation.
+    - Admin (read_rtp_all): isActive must be true — role grants visibility across all SPs.
+    Same payer, same endpoint, different roles → different results.
+    """
+    _activation_id, debtor_fc = make_activation()
+
+    res_sp_b = get_activation_status_by_fiscal_code(debtor_service_provider_token_b, debtor_fc)
+    assert res_sp_b.status_code == 200, f"Expected 200 but got {res_sp_b.status_code}: {res_sp_b.text}"
+    assert res_sp_b.json()["isActive"] is False, (
+        f"read_rtp_activations (SP B): expected isActive=false for cross-SP payer but got: {res_sp_b.json()}"
+    )
+
+    res_admin = get_activation_status_by_fiscal_code(sp_activations_read_all_token, debtor_fc)
+    assert res_admin.status_code == 200, f"Expected 200 but got {res_admin.status_code}: {res_admin.text}"
+    assert res_admin.json()["isActive"] is True, (
+        f"read_rtp_all (admin): expected isActive=true for cross-SP payer but got: {res_admin.json()}"
+    )
+
+
+@allure.epic("Debtor Activation")
+@allure.feature("Payer Status")
+@allure.story("Get Activation Status by Fiscal Code")
+@allure.title("A deactivated payer returns isActive false")
+@allure.tag("functional", "happy_path", "activation", "payer_status")
+@pytest.mark.activation
+@pytest.mark.happy_path
+def test_get_activation_status_deactivated_payer(debtor_service_provider_token_a, make_activation):
+    """Payer activated then deactivated by SP A → isActive must be false."""
+    activation_id, debtor_fc = make_activation()
+
+    deactivate_res = deactivate(debtor_service_provider_token_a, activation_id)
+    assert deactivate_res.status_code == 204, (
+        f"Deactivation failed: expected 204 but got {deactivate_res.status_code}: {deactivate_res.text}"
+    )
+
+    res = get_activation_status_by_fiscal_code(debtor_service_provider_token_a, debtor_fc)
+    assert res.status_code == 200, f"Expected 200 but got {res.status_code}: {res.text}"
+    assert res.json()["isActive"] is False, f"Expected isActive=false after deactivation but got: {res.json()}"
+
+
+@allure.epic("Debtor Activation")
+@allure.feature("Payer Status")
+@allure.story("Get Activation Status by Fiscal Code")
+@allure.title("An active payer with omocodia fiscal code returns isActive true")
+@allure.tag("functional", "happy_path", "activation", "payer_status", "omocodia")
+@pytest.mark.activation
+@pytest.mark.happy_path
+def test_get_activation_status_omocodia_fiscal_code(
+    debtor_service_provider_token_a, make_activation, random_omocodia_fiscal_code
+):
+    """Active payer with omocodia fiscal code (digit substitution) → isActive must be true."""
+    _activation_id, _ = make_activation(random_omocodia_fiscal_code)
+
+    res = get_activation_status_by_fiscal_code(debtor_service_provider_token_a, random_omocodia_fiscal_code)
+    assert res.status_code == 200, f"Expected 200 but got {res.status_code}: {res.text}"
+    assert res.json()["isActive"] is True, f"Expected isActive=true for omocodia FC but got: {res.json()}"
+
+
+@allure.epic("Debtor Activation")
+@allure.feature("Payer Status")
+@allure.story("Get Activation Status by Fiscal Code")
+@allure.title("An active payer with foreign fiscal code returns isActive true")
+@allure.tag("functional", "happy_path", "activation", "payer_status", "foreign")
+@pytest.mark.activation
+@pytest.mark.happy_path
+def test_get_activation_status_foreign_fiscal_code(
+    debtor_service_provider_token_a, make_activation, random_foreign_fiscal_code
+):
+    """Active payer with a foreign-country fiscal code (Z + 3 digits municipality) → isActive must be true."""
+    _activation_id, _ = make_activation(random_foreign_fiscal_code)
+
+    res = get_activation_status_by_fiscal_code(debtor_service_provider_token_a, random_foreign_fiscal_code)
+    assert res.status_code == 200, f"Expected 200 but got {res.status_code}: {res.text}"
+    assert res.json()["isActive"] is True, f"Expected isActive=true for foreign FC but got: {res.json()}"
+
+
+@allure.epic("Debtor Activation")
+@allure.feature("Payer Status")
+@allure.story("Get Activation Status by Fiscal Code")
+@allure.title("An active payer with VAT number (Partita IVA) returns isActive true")
+@allure.tag("functional", "happy_path", "activation", "payer_status", "vat")
+@pytest.mark.activation
+@pytest.mark.happy_path
+def test_get_activation_status_vat_number(debtor_service_provider_token_a, make_activation, random_vat_number):
+    """Active payer identified by an 11-digit Partita IVA → isActive must be true."""
+    _activation_id, _ = make_activation(random_vat_number)
+
+    res = get_activation_status_by_fiscal_code(debtor_service_provider_token_a, random_vat_number)
+    assert res.status_code == 200, f"Expected 200 but got {res.status_code}: {res.text}"
+    assert res.json()["isActive"] is True, f"Expected isActive=true for VAT number but got: {res.json()}"
+
+
+@allure.epic("Debtor Activation")
+@allure.feature("Payer Status")
+@allure.story("Get Activation Status by Fiscal Code")
+@allure.title("Querying activation status without a valid token returns 401")
+@allure.tag("functional", "unhappy_path", "activation", "payer_status")
+@pytest.mark.activation
+@pytest.mark.unhappy_path
+def test_get_activation_status_unauthorized():
+    """Missing or invalid Bearer token → the endpoint must return 401."""
+    fake_token = "Bearer invalid.token.value"
+    res = get_activation_status_by_fiscal_code(fake_token, "RSSMRA85T10A562S")
+    assert res.status_code == 401, f"Expected 401 but got {res.status_code}: {res.text}"
+
+
+@allure.epic("Debtor Activation")
+@allure.feature("Payer Status")
+@allure.story("Get Activation Status by Fiscal Code")
+@allure.title("Querying activation status without the PayerId header returns 400")
+@allure.tag("functional", "unhappy_path", "activation", "payer_status")
+@pytest.mark.activation
+@pytest.mark.unhappy_path
+def test_get_activation_status_missing_payer_id_header(debtor_service_provider_token_a):
+    """Request without the required ``PayerId`` header → must return 400."""
+    res = get_activation_status_without_payer_id(debtor_service_provider_token_a)
+    assert res.status_code == 400, f"Expected 400 but got {res.status_code}: {res.text}"
+
+
+@allure.epic("Debtor Activation")
+@allure.feature("Payer Status")
+@allure.story("Get Activation Status by Fiscal Code")
+@allure.title("Querying activation status with an invalid payerId format returns 400")
+@allure.tag("functional", "unhappy_path", "activation", "payer_status")
+@pytest.mark.activation
+@pytest.mark.unhappy_path
+@pytest.mark.parametrize("description,invalid_payer_id", _INVALID_PAYER_IDS)
+def test_get_activation_status_invalid_payer_id_format(
+    debtor_service_provider_token_a, description, invalid_payer_id
+):
+    """Each entry in ``_INVALID_PAYER_IDS`` must be rejected with 400.
+
+    The ``description`` parameter appears in pytest output to identify which
+    case failed without having to inspect the raw value.
+    """
+    res = get_activation_status_by_fiscal_code(debtor_service_provider_token_a, invalid_payer_id)
+    assert res.status_code == 400, (
+        f"[{description}] Expected 400 but got {res.status_code}: {res.text}"
+    )

--- a/out/production/rtp-platform-qa/utils/fiscal_code_utils.py
+++ b/out/production/rtp-platform-qa/utils/fiscal_code_utils.py
@@ -6,21 +6,57 @@ from faker import Faker
 fake = Faker("it_IT")
 
 _FOREIGN_CODE_RANGES = [
-    (100, 156), (200, 259), (300, 368), (400, 404),
-    (500, 524), (600, 614), (700, 735), (800, 802), (900, 906),
+    (100, 156),
+    (200, 259),
+    (300, 368),
+    (400, 404),
+    (500, 524),
+    (600, 614),
+    (700, 735),
+    (800, 802),
+    (900, 906),
 ]
 
 _OMOCODIA_POSITIONS = [14, 13, 12, 10, 9, 7, 6]
 _OMOCODIA_MAP = dict(zip("0123456789", "LMNPQRSTUV"))
 
 _CF_ODD_VALUES = {
-    '0': 1,  '1': 0,  '2': 5,  '3': 7,  '4': 9,
-    '5': 13, '6': 15, '7': 17, '8': 19, '9': 21,
-    'A': 1,  'B': 0,  'C': 5,  'D': 7,  'E': 9,
-    'F': 13, 'G': 15, 'H': 17, 'I': 19, 'J': 21,
-    'K': 2,  'L': 4,  'M': 18, 'N': 20, 'O': 11,
-    'P': 3,  'Q': 6,  'R': 8,  'S': 12, 'T': 14,
-    'U': 16, 'V': 10, 'W': 22, 'X': 25, 'Y': 24, 'Z': 23,
+    "0": 1,
+    "1": 0,
+    "2": 5,
+    "3": 7,
+    "4": 9,
+    "5": 13,
+    "6": 15,
+    "7": 17,
+    "8": 19,
+    "9": 21,
+    "A": 1,
+    "B": 0,
+    "C": 5,
+    "D": 7,
+    "E": 9,
+    "F": 13,
+    "G": 15,
+    "H": 17,
+    "I": 19,
+    "J": 21,
+    "K": 2,
+    "L": 4,
+    "M": 18,
+    "N": 20,
+    "O": 11,
+    "P": 3,
+    "Q": 6,
+    "R": 8,
+    "S": 12,
+    "T": 14,
+    "U": 16,
+    "V": 10,
+    "W": 22,
+    "X": 25,
+    "Y": 24,
+    "Z": 23,
 }
 
 
@@ -171,6 +207,7 @@ def _vat_check_digit(digits: list) -> int:
     even_sum = sum(d * 2 if d * 2 < 10 else d * 2 - 9 for d in (digits[i] for i in range(1, 10, 2)))
     return (10 - (odd_sum + even_sum) % 10) % 10
 
+
 def _cf_checksum(cf: list) -> str:
     """Compute the control character for an Italian fiscal code.
 
@@ -181,7 +218,7 @@ def _cf_checksum(cf: list) -> str:
         The control character (A–Z).
     """
     total = sum(
-        _CF_ODD_VALUES[c] if i % 2 == 0 else (ord(c) - ord('A') if c.isalpha() else int(c))
+        _CF_ODD_VALUES[c] if i % 2 == 0 else (ord(c) - ord("A") if c.isalpha() else int(c))
         for i, c in enumerate(cf[:15])
     )
-    return chr(ord('A') + total % 26)
+    return chr(ord("A") + total % 26)

--- a/utils/dataset_payer_id_invalid.py
+++ b/utils/dataset_payer_id_invalid.py
@@ -1,0 +1,50 @@
+"""Invalid payer identifier test dataset.
+
+``INVALID_PAYER_IDS`` is a list of ``(description, value)`` pairs covering every
+invalid fiscal-code and VAT-number format that the RTP platform must reject with
+a 400 response.  Import it wherever parametrized negative-path assertions on
+``payerId`` are needed.
+
+Validation rules enforced by the backend:
+
+- **Fiscal code**: 16 uppercase alphanumeric characters, valid month code
+  (A B C D E H L M P R S T), birth day in range 01–31 (male) or 41–71 (female),
+  and a correct Luhn-style control character.
+- **VAT number**: exactly 11 decimal digits.
+
+Edge-case rationale
+-------------------
+- **Month codes**: the valid set is non-contiguous.  F and G (between valid E and H)
+  and U are the most common off-by-one mistakes in validators.
+- **Birth day dead zone**: 32–40 is always invalid (male max = 31, female min = 41).
+- **EU VAT prefix**: ``IT`` + 11 digits produces a 13-char string — a common client
+  mistake that must be rejected on length grounds before any digit check.
+- **Checksum probe** (``cf_wrong_checksum``): syntactically valid CF with a wrong
+  control character.  Acts as a TDD sentinel — stays red until the backend enforces
+  checksum validation.
+"""
+
+INVALID_PAYER_IDS = [
+    ("too_short_fiscal_code", "XCGCHS98M13F16"),
+    ("too_long_fiscal_code", "XCGCHS98M13F166EXX"),
+    ("vat_number_10_digits", "1234567890"),
+    ("vat_number_12_digits", "123456789012"),
+    ("lowercase_fiscal_code", "xcgchs98m13f166e"),
+    ("mixed_case_fiscal_code", "XcGCHS98M13F166E"),
+    ("invalid_month_code_F", "XCGCHS98F13F166E"),
+    ("invalid_month_code_G", "XCGCHS98G13F166E"),
+    ("invalid_month_code_U", "XCGCHS98U13F166E"),
+    ("invalid_birth_day_00", "XCGCHS98M00F166E"),
+    ("invalid_birth_day_32_male", "XCGCHS98M32F166E"),
+    ("invalid_birth_day_40_dead_zone", "XCGCHS98M40F166E"),
+    ("invalid_birth_day_72_female", "XCGCHS98M72F166E"),
+    ("non_alphanumeric_character", "XCGCHS98M13F166!"),
+    ("space_in_fiscal_code", "XCGCHS98M13 F66E"),
+    ("cf_with_leading_whitespace", " XCGCHS98M13F166E"),
+    ("cf_with_trailing_whitespace", "XCGCHS98M13F166E "),
+    ("non_numeric_vat_like", "ABCDEFGHIJK"),
+    ("all_zeros_10_digits", "0000000000"),
+    ("vat_with_eu_it_prefix", "IT12345678903"),
+    ("cf_wrong_checksum", "RSSMRA85T10A562T"),
+    ("empty_string", ""),
+]


### PR DESCRIPTION
### Description

This PR adds a functional test suite for the `GET /activations/payer/{payerId}/status` endpoint introduced in the `rtp-activator` service. The endpoint returns a minimal `{ "isActive": true/false }` response indicating whether a payer (identified by fiscal code or VAT number) is currently enrolled in the RTP system, without exposing any PII or cross-SP information.

### List of changes

- **`functional-tests/tests/activation/test_debtor_activation_payer_status.py`** — new test suite (12 test cases, 32 parametrized variants) covering:
  - Happy paths: active payer same SP, never-activated payer, payer active on a different SP (privacy rule enforcement), `read_rtp_all` admin role, deactivated payer, omocodia fiscal code, foreign fiscal code, VAT number (Partita IVA)
  - Unhappy paths: invalid token (401), 22 parametrized invalid `payerId` formats (400) mirroring the Java test data source and extended with CF/PIVA structural edge cases
- **`api/debtor_activation_api.py`** — new client function `get_activation_status_by_fiscal_code`; `payerId` is passed as a **path parameter** (`/activations/payer/{payerId}/status`)
- **`api/utils/endpoints.py`** — new `ACTIVATION_PAYER_STATUS_URL` template constant
- **`config.yaml`** — new `activation_payer_status_path: "/activations/payer/{payerId}/status"` entry
- **`utils/dataset_payer_id_invalid.py`** — new shared dataset of invalid `payerId` values, reusable across test modules

### Motivation and context

The `GET /activations/payer/{payerId}/status` endpoint was added to allow Service Providers to check whether a payer is enrolled in RTP without fetching full activation records. A key privacy rule governs it: the response is deliberately indistinguishable between "payer not found" and "payer active under a different SP" — both return `{ "isActive": false }` — to prevent SPs from probing competitors' customer bases. This suite validates both the business logic and the privacy guarantee across RBAC roles (`read_rtp_activations` vs `read_rtp_all`).

> **Note:** the `cf_wrong_checksum` entry in the parametrized 400 suite is intentionally kept as a TDD sentinel — it will stay red until the backend enforces Italian CF checksum validation.

### Aggregation level

- [ ] Test case
- [x] Test suite

### Test type

- [x] Functional test
- [ ] Bdd test
- [ ] Performance
- [ ] End to end

### Type of changes

- [x] Add new test case/suite
- [ ] Modify existing test case/suite

### Test Results

- [ ] Success
- [x] Failure
- [ ] Poor performance
- [ ] Good performance

### Did you update secrets accordingly?

- [x] Not needed

### Did you update dependencies accordingly?

- [x] Not needed
