### PR TITLE
fix: [SRTP-1980] allure decorator on new line

### DIFF
--- a/functional-tests/tests/activation/test_debtor_activation_payer_status.py
+++ b/functional-tests/tests/activation/test_debtor_activation_payer_status.py
@@ -230,7 +230,6 @@ def test_get_activation_status_unauthorized():
 
 
 @allure.epic("Debtor Activation")
-@allure.epic("Debtor Activation")
 @allure.feature("Payer Status")
 @allure.story("Get Activation Status by Fiscal Code")
 @allure.title("Querying activation status with an invalid payerId format returns 400")

--- a/functional-tests/tests/activation/test_debtor_activation_payer_status.py
+++ b/functional-tests/tests/activation/test_debtor_activation_payer_status.py
@@ -233,7 +233,8 @@ def test_get_activation_status_unauthorized():
 @allure.epic("Debtor Activation")
 @allure.feature("Payer Status")
 @allure.story("Get Activation Status by Fiscal Code")
-@allure.title("Querying activation status with an invalid payerId format returns 400")@allure.tag("functional", "unhappy_path", "activation", "payer_status")
+@allure.title("Querying activation status with an invalid payerId format returns 400")
+@allure.tag("functional", "unhappy_path", "activation", "payer_status")
 @pytest.mark.activation
 @pytest.mark.unhappy_path
 @pytest.mark.parametrize("description,invalid_payer_id", INVALID_PAYER_IDS)


### PR DESCRIPTION
### Description

Pytest was failing identifying new tests.

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

Add newline on decorator to solve repository issue where new tests would not be found.

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Aggregation level

<!--- Did you write a single reusable test case, or a full test suite?  -->

- [x] Test case
- [ ] Test suite

### Test type

- [x] Functional test
- [ ] Bdd test
- [ ] Performance
- [ ] End to end
- [ ] Performance

### Type of changes

- [ ] Add new test case/suite
- [x] Modify existing test case/suite

### Test Results

- [ ] Success
- [x] Failure
- [ ] Poor performance
- [ ] Good performance

### Did you update secrets accordingly?

- [ ] Yes
  - [ ] `.secrets_template.yaml`
  - [ ] Pipelines' secure file
  - [ ] Confluence
- [x] Not needed
- [ ] No (_please provide further information_)

### Did you update dependencies accordingly?

- [ ] Yes (which requirements.txt did you update?)
<!--- Describe which requirements.txt did you update -->
- [x] Not needed


### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
