### PR TITLE
fix: [SRTP-1996] update callback functions to conditionally include version headers

### DIFF
--- a/api/RTP_callback_api.py
+++ b/api/RTP_callback_api.py
@@ -5,17 +5,18 @@ from api.utils.endpoints import CALLBACK_URL, RFC_CALLBACK_URL
 from api.utils.http_utils import HTTP_TIMEOUT
 
 
-def srtp_callback(cert_path: str, key_path: str, rtp_payload):
+def srtp_callback(cert_path: str, key_path: str, rtp_payload, include_version_header: bool = True):
+    headers = {"Version": CALLBACK_VERSION} if include_version_header else {}
     return requests.post(
         cert=(cert_path, key_path),
         url=CALLBACK_URL,
-        headers={"Version": CALLBACK_VERSION},
+        headers=headers,
         json=rtp_payload,
         timeout=HTTP_TIMEOUT,
     )
 
 
-def srtp_rfc_callback(cert_path: str, key_path: str, rtp_payload):
+def srtp_rfc_callback(cert_path: str, key_path: str, rtp_payload, include_version_header: bool = True):
     """
     Send RFC (Request for Cancellation) callback.
 
@@ -26,14 +27,16 @@ def srtp_rfc_callback(cert_path: str, key_path: str, rtp_payload):
         cert_path: Path to the certificate file
         key_path: Path to the key file
         rtp_payload: The RFC callback payload (DS12P or DS12N)
+        include_version_header: When False, omits the Version header (used for regression tests)
 
     Returns:
         Response object from the callback request
     """
+    headers = {"Version": RFC_CALLBACK_VERSION} if include_version_header else {}
     return requests.post(
         cert=(cert_path, key_path),
         url=RFC_CALLBACK_URL,
-        headers={"Version": RFC_CALLBACK_VERSION},
+        headers=headers,
         json=rtp_payload,
         timeout=HTTP_TIMEOUT,
     )

--- a/api/RTP_callback_api.py
+++ b/api/RTP_callback_api.py
@@ -5,7 +5,7 @@ from api.utils.endpoints import CALLBACK_URL, RFC_CALLBACK_URL
 from api.utils.http_utils import HTTP_TIMEOUT
 
 
-def srtp_callback(cert_path: str, key_path: str, rtp_payload, include_version_header: bool = True):
+def srtp_callback(cert_path: str, key_path: str, rtp_payload, include_version_header: bool = False):
     headers = {"Version": CALLBACK_VERSION} if include_version_header else {}
     return requests.post(
         cert=(cert_path, key_path),
@@ -16,7 +16,7 @@ def srtp_callback(cert_path: str, key_path: str, rtp_payload, include_version_he
     )
 
 
-def srtp_rfc_callback(cert_path: str, key_path: str, rtp_payload, include_version_header: bool = True):
+def srtp_rfc_callback(cert_path: str, key_path: str, rtp_payload, include_version_header: bool = False):
     """
     Send RFC (Request for Cancellation) callback.
 
@@ -27,7 +27,7 @@ def srtp_rfc_callback(cert_path: str, key_path: str, rtp_payload, include_versio
         cert_path: Path to the certificate file
         key_path: Path to the key file
         rtp_payload: The RFC callback payload (DS12P or DS12N)
-        include_version_header: When False, omits the Version header (used for regression tests)
+        include_version_header: When True, adds the Version header to the request
 
     Returns:
         Response object from the callback request

--- a/functional-tests/tests/callbacks/test_RTP_callback_DS_04.py
+++ b/functional-tests/tests/callbacks/test_RTP_callback_DS_04.py
@@ -50,6 +50,7 @@ def test_receive_rtp_callback_DS_04b_compliant(
         rtp_payload=callback_data,
         cert_path=cert,
         key_path=key,
+        include_version_header=False,
     )
     assert callback_response.status_code == 200, (
         f"Error from callback, expected 200 got {callback_response.status_code}"
@@ -75,6 +76,7 @@ def test_fail_send_rtp_callback_wrong_certificate_serial_DS_04b_compliant(
         rtp_payload=callback_data,
         cert_path=cert,
         key_path=key,
+        include_version_header=False,
     )
     assert callback_response.status_code == 403, (
         f"Expecting error from callback, expected 403 got {callback_response.status_code}"
@@ -100,6 +102,7 @@ def test_fail_send_rtp_callback_non_existing_service_provider_DS_04b_compliant(
         rtp_payload=callback_data,
         cert_path=cert,
         key_path=key,
+        include_version_header=False,
     )
     assert callback_response.status_code == 400, (
         f"Expecting error from callback, expected 400 got {callback_response.status_code}"
@@ -153,6 +156,7 @@ def test_fail_send_rtp_callback_non_compliant_payload_DS_04b_compliant(
         rtp_payload=callback_data,
         cert_path=cert,
         key_path=key,
+        include_version_header=False,
     )
     assert callback_response.status_code == 400, (
         f"Error from callback, expected 400 got {callback_response.status_code}"

--- a/functional-tests/tests/callbacks/test_RTP_callback_DS_05.py
+++ b/functional-tests/tests/callbacks/test_RTP_callback_DS_05.py
@@ -51,6 +51,7 @@ def test_receive_rtp_callback_DS_05_ACTC_compliant(
         rtp_payload=callback_data,
         cert_path=cert,
         key_path=key,
+        include_version_header=False,
     )
     assert callback_response.status_code == 200, (
         f"Error from callback, expected 200 got {callback_response.status_code}"
@@ -114,6 +115,7 @@ def test_receive_rtp_callback_DS_05_ACTC_non_compliant(
         rtp_payload=callback_data,
         cert_path=cert,
         key_path=key,
+        include_version_header=False,
     )
     assert callback_response.status_code == 400, (
         f"Error from callback, expected 400 got {callback_response.status_code}"
@@ -167,6 +169,7 @@ def test_fail_send_rtp_callback_invalid_transition_DS_05_ACTC_compliant(
         rtp_payload=callback_data,
         cert_path=cert,
         key_path=key,
+        include_version_header=False,
     )
     assert first_callback_response.status_code == 200, (
         f"Error from first callback, expected 200 got {first_callback_response.status_code}"
@@ -184,6 +187,7 @@ def test_fail_send_rtp_callback_invalid_transition_DS_05_ACTC_compliant(
         rtp_payload=callback_data,
         cert_path=cert,
         key_path=key,
+        include_version_header=False,
     )
     assert second_callback_response.status_code == 400, (
         f"Error from second callback, expected 400 got {second_callback_response.status_code}"

--- a/functional-tests/tests/callbacks/test_RTP_callback_DS_08.py
+++ b/functional-tests/tests/callbacks/test_RTP_callback_DS_08.py
@@ -54,6 +54,7 @@ def test_receive_rtp_callback_DS_08P_compliant_ACCP(
         rtp_payload=callback_data,
         cert_path=cert,
         key_path=key,
+        include_version_header=False,
     )
     assert callback_response.status_code == 200, (
         f"Error from callback, expected 200 got {callback_response.status_code}"
@@ -78,6 +79,7 @@ def test_receive_rtp_callback_DS_08P_compliant_ACCP(
         rtp_payload=callback_data,
         cert_path=cert,
         key_path=key,
+        include_version_header=False,
     )
     assert callback_response.status_code == 200, (
         f"Error from callback, expected 200 got {callback_response.status_code}"
@@ -131,6 +133,7 @@ def test_receive_rtp_callback_DS_08P_compliant_RJCT(
         rtp_payload=callback_data,
         cert_path=cert,
         key_path=key,
+        include_version_header=False,
     )
     assert callback_response.status_code == 200, (
         f"Error from callback, expected 200 got {callback_response.status_code}"
@@ -155,6 +158,7 @@ def test_receive_rtp_callback_DS_08P_compliant_RJCT(
         rtp_payload=callback_data,
         cert_path=cert,
         key_path=key,
+        include_version_header=False,
     )
     assert callback_response.status_code == 200, (
         f"Error from callback, expected 200 got {callback_response.status_code}"
@@ -188,6 +192,7 @@ def test_fail_send_rtp_callback_non_existing_service_provider_DS_08N_compliant(
         rtp_payload=callback_data,
         cert_path=cert,
         key_path=key,
+        include_version_header=False,
     )
     assert callback_response.status_code == 400, (
         f"Expecting error from callback, expected 400 got {callback_response.status_code}"
@@ -241,6 +246,7 @@ def test_receive_rtp_callback_DS_08P_compliant_ACWC(
         rtp_payload=callback_data,
         cert_path=cert,
         key_path=key,
+        include_version_header=False,
     )
     assert callback_response.status_code == 400, (
         f"Error from callback, expected 400 got {callback_response.status_code}"
@@ -275,6 +281,7 @@ def test_fail_send_rtp_callback_wrong_certificate_serial_DS_08N_compliant(
         rtp_payload=callback_data,
         cert_path=cert,
         key_path=key,
+        include_version_header=False,
     )
     assert callback_response.status_code == 403, (
         f"Expecting error from callback, expected 403 got {callback_response.status_code}"
@@ -320,6 +327,7 @@ def test_receive_rtp_callback_DS_08N_compliant(
         rtp_payload=callback_data,
         cert_path=cert,
         key_path=key,
+        include_version_header=False,
     )
     assert callback_response.status_code == 200, (
         f"Error from callback, expected 200 got {callback_response.status_code}"
@@ -372,6 +380,7 @@ def test_receive_rtp_callback_DS_08P_invalid(
         rtp_payload=callback_data,
         cert_path=cert,
         key_path=key,
+        include_version_header=False,
     )
     assert callback_response.status_code == 400, (
         f"Error from callback, expected 400 got {callback_response.status_code}"
@@ -425,6 +434,7 @@ def test_receive_rtp_callback_DS_08N_invalid(
         rtp_payload=callback_data,
         cert_path=cert,
         key_path=key,
+        include_version_header=False,
     )
     assert callback_response.status_code == 400, (
         f"Error from callback, expected 400 got {callback_response.status_code}"

--- a/functional-tests/tests/callbacks/test_RTP_callback_DS_12N.py
+++ b/functional-tests/tests/callbacks/test_RTP_callback_DS_12N.py
@@ -64,6 +64,7 @@ def test_receive_rfc_callback_DS_12N_RJCR_compliant(
         rtp_payload=callback_data,
         cert_path=cert,
         key_path=key,
+        include_version_header=False,
     )
     assert callback_response.status_code == 200, (
         f"Error from callback, expected 200 got {callback_response.status_code}"
@@ -130,6 +131,7 @@ def test_fail_send_rfc_callback_wrong_certificate_serial_DS_12N_RJCR_compliant(
         rtp_payload=callback_data,
         cert_path=cert,
         key_path=key,
+        include_version_header=False,
     )
     assert callback_response.status_code == 403, (
         f"Expecting error from callback, expected 403 got {callback_response.status_code}"
@@ -188,6 +190,7 @@ def test_fail_send_rfc_callback_non_existing_service_provider_DS_12N_RJCR_compli
         rtp_payload=callback_data,
         cert_path=cert,
         key_path=key,
+        include_version_header=False,
     )
     assert callback_response.status_code == 400, (
         f"Expecting error from callback, expected 400 got {callback_response.status_code}"
@@ -247,6 +250,7 @@ def test_receive_rfc_callback_DS_12N_invalid(
         rtp_payload=callback_data,
         cert_path=cert,
         key_path=key,
+        include_version_header=False,
     )
     assert callback_response.status_code == 400, (
         f"Error from callback, expected 400 got {callback_response.status_code}"
@@ -318,6 +322,7 @@ def test_receive_rfc_callback_DS_12N_RJCR_compliant_THROUGH_WEB_API(
         rtp_payload=callback_data,
         cert_path=cert,
         key_path=key,
+        include_version_header=False,
     )
     assert callback_response.status_code == 200, (
         f"Error from callback, expected 200 got {callback_response.status_code}"
@@ -386,6 +391,7 @@ def test_fail_send_rfc_callback_wrong_certificate_serial_DS_12N_RJCR_compliant_T
         rtp_payload=callback_data,
         cert_path=cert,
         key_path=key,
+        include_version_header=False,
     )
     assert callback_response.status_code == 403, (
         f"Expecting error from callback, expected 403 got {callback_response.status_code}"
@@ -446,6 +452,7 @@ def test_fail_send_rfc_callback_non_existing_service_provider_DS_12N_RJCR_compli
         rtp_payload=callback_data,
         cert_path=cert,
         key_path=key,
+        include_version_header=False,
     )
     assert callback_response.status_code == 400, (
         f"Expecting error from callback, expected 400 got {callback_response.status_code}"
@@ -507,6 +514,7 @@ def test_receive_rfc_callback_DS_12N_invalid_THROUGH_WEB_API(
         rtp_payload=callback_data,
         cert_path=cert,
         key_path=key,
+        include_version_header=False,
     )
     assert callback_response.status_code == 400, (
         f"Error from callback, expected 400 got {callback_response.status_code}"

--- a/functional-tests/tests/callbacks/test_RTP_callback_DS_12P.py
+++ b/functional-tests/tests/callbacks/test_RTP_callback_DS_12P.py
@@ -64,6 +64,7 @@ def test_receive_rfc_callback_DS_12P_CNCL_compliant(
         rtp_payload=callback_data,
         cert_path=cert,
         key_path=key,
+        include_version_header=False,
     )
     assert callback_response.status_code == 200, (
         f"Error from callback, expected 200 got {callback_response.status_code}"
@@ -130,6 +131,7 @@ def test_fail_send_rfc_callback_wrong_certificate_serial_DS_12P_CNCL_compliant(
         rtp_payload=callback_data,
         cert_path=cert,
         key_path=key,
+        include_version_header=False,
     )
     assert callback_response.status_code == 403, (
         f"Expecting error from callback, expected 403 got {callback_response.status_code}"
@@ -188,6 +190,7 @@ def test_fail_send_rfc_callback_non_existing_service_provider_DS_12P_CNCL_compli
         rtp_payload=callback_data,
         cert_path=cert,
         key_path=key,
+        include_version_header=False,
     )
     assert callback_response.status_code == 400, (
         f"Expecting error from callback, expected 400 got {callback_response.status_code}"
@@ -247,6 +250,7 @@ def test_receive_rfc_callback_DS_12P_invalid(
         rtp_payload=callback_data,
         cert_path=cert,
         key_path=key,
+        include_version_header=False,
     )
     assert callback_response.status_code == 400, (
         f"Error from callback, expected 400 got {callback_response.status_code}"
@@ -316,6 +320,7 @@ def test_receive_rfc_callback_DS_12P_CNCL_compliant_THROUGH_WEB_API(
         rtp_payload=callback_data,
         cert_path=cert,
         key_path=key,
+        include_version_header=False,
     )
     assert callback_response.status_code == 200, (
         f"Error from callback, expected 200 got {callback_response.status_code}"
@@ -384,6 +389,7 @@ def test_fail_send_rfc_callback_wrong_certificate_serial_DS_12P_CNCL_compliant_T
         rtp_payload=callback_data,
         cert_path=cert,
         key_path=key,
+        include_version_header=False,
     )
     assert callback_response.status_code == 403, (
         f"Expecting error from callback, expected 403 got {callback_response.status_code}"
@@ -444,6 +450,7 @@ def test_fail_send_rfc_callback_non_existing_service_provider_DS_12P_CNCL_compli
         rtp_payload=callback_data,
         cert_path=cert,
         key_path=key,
+        include_version_header=False,
     )
     assert callback_response.status_code == 400, (
         f"Expecting error from callback, expected 400 got {callback_response.status_code}"
@@ -505,6 +512,7 @@ def test_receive_rfc_callback_DS_12P_invalid_THROUGH_WEB_API(
         rtp_payload=callback_data,
         cert_path=cert,
         key_path=key,
+        include_version_header=False,
     )
     assert callback_response.status_code == 400, (
         f"Error from callback, expected 400 got {callback_response.status_code}"

--- a/functional-tests/tests/callbacks/test_RTP_callback_with_version_header.py
+++ b/functional-tests/tests/callbacks/test_RTP_callback_with_version_header.py
@@ -1,0 +1,430 @@
+"""Regression tests: all callback endpoints must reject requests that include the Version header.
+
+The backend was updated to route callbacks without the ``Version`` header.  Sending the
+header now causes the request to hit a removed/unknown route, returning 404.
+Each test sends a syntactically valid payload over mTLS WITH the ``Version`` header and
+verifies the callback is rejected (404) and the RTP state is not affected.
+If any of these tests begin returning 200 it means versioned routing has been
+re-introduced — a regression.
+
+Coverage:
+- DS_04b  (RTP callback endpoint)
+- DS_05   (RTP callback endpoint)
+- DS_08P  (RTP callback endpoint)
+- DS_08N  (RTP callback endpoint)
+- DS_12P  (RFC callback endpoint)
+- DS_12N  (RFC callback endpoint)
+"""
+
+import allure
+import pytest
+
+from api.RTP_callback_api import srtp_callback, srtp_rfc_callback
+from api.RTP_get_api import get_rtp
+from api.RTP_process_sender import send_gpd_message
+from utils.callback_builder import build_callback_with_original_msg_id
+from utils.dataset_callback_data_DS_04b_compliant import generate_callback_data_DS_04b_compliant
+from utils.dataset_callback_data_DS_05_ACTC_compliant import generate_callback_data_DS_05_ACTC_compliant
+from utils.dataset_callback_data_DS_08N_compliant import generate_callback_data_DS_08N_compliant
+from utils.dataset_callback_data_DS_08P_ACCP_compliant import generate_callback_data_DS_08P_ACCP_compliant
+from utils.dataset_callback_data_DS_12N_RJCR_compliant import generate_callback_data_DS_12N_RJCR_compliant
+from utils.dataset_callback_data_DS_12P_CNCL_compliant import generate_callback_data_DS_12P_CNCL_compliant
+from utils.dataset_gpd_message import generate_gpd_delete_message_payload, generate_gpd_message_payload
+
+
+# ---------------------------------------------------------------------------
+# RTP callback endpoint (DS_04, DS_05, DS_08)
+# ---------------------------------------------------------------------------
+
+
+@allure.epic("RTP Callback")
+@allure.feature("RTP Callback - Version Header")
+@allure.story("Callback with Version header is rejected")
+@allure.title("DS_04b callback with Version header returns 404")
+@allure.tag("functional", "unhappy_path", "rtp_callback", "regression", "version_header")
+@pytest.mark.callback
+@pytest.mark.unhappy_path
+def test_rtp_callback_DS_04b_with_version_header(
+    rtp_consumer_access_token,
+    activate_payer,
+    random_fiscal_code,
+    debtor_sp_mock_cert_key,
+):
+    """
+    DS_04b callback sent with the Version header must be rejected with 404.
+
+    Flow:
+    1. Activate payer and send an RTP → resource_id
+    2. Build a valid DS_04b payload referencing the RTP
+    3. POST to callback endpoint WITH Version header
+    4. Verify 404 is returned
+    """
+    message_payload = generate_gpd_message_payload(fiscal_code=random_fiscal_code, operation="CREATE", status="VALID")
+
+    activation_response = activate_payer(random_fiscal_code)
+    assert activation_response.status_code == 201
+
+    send_response = send_gpd_message(access_token=rtp_consumer_access_token, message_payload=message_payload)
+    assert send_response.status_code == 200
+
+    resource_id = send_response.json()["resourceId"]
+    assert resource_id is not None, "Missing resourceId in send GPD message response"
+    original_msg_id = resource_id.replace("-", "")
+
+    callback_data = build_callback_with_original_msg_id(
+        generate_callback_data_DS_04b_compliant,
+        original_msg_id,
+        is_document=False,
+    )
+
+    cert, key = debtor_sp_mock_cert_key
+
+    callback_response = srtp_callback(
+        rtp_payload=callback_data,
+        cert_path=cert,
+        key_path=key,
+    )
+    assert callback_response.status_code == 404, (
+        f"Expected 404 (Version header should be rejected) but got {callback_response.status_code}"
+    )
+
+
+@allure.epic("RTP Callback")
+@allure.feature("RTP Callback - Version Header")
+@allure.story("Callback with Version header is rejected")
+@allure.title("DS_05 ACTC callback with Version header returns 404")
+@allure.tag("functional", "unhappy_path", "rtp_callback", "regression", "version_header")
+@pytest.mark.callback
+@pytest.mark.unhappy_path
+def test_rtp_callback_DS_05_ACTC_with_version_header(
+    rtp_consumer_access_token,
+    rtp_reader_access_token,
+    activate_payer,
+    random_fiscal_code,
+    debtor_sp_mock_cert_key,
+):
+    """
+    DS_05 ACTC callback sent with the Version header must be rejected with 404.
+    The RTP must remain in SENT (transition to ACCEPTED must not happen).
+
+    Flow:
+    1. Activate payer and send an RTP → resource_id
+    2. Build a valid DS_05 ACTC payload referencing the RTP
+    3. POST to callback endpoint WITH Version header
+    4. Verify 404 is returned
+    5. Verify RTP status is still SENT
+    """
+    message_payload = generate_gpd_message_payload(fiscal_code=random_fiscal_code, operation="CREATE", status="VALID")
+
+    activation_response = activate_payer(random_fiscal_code)
+    assert activation_response.status_code == 201
+
+    send_response = send_gpd_message(access_token=rtp_consumer_access_token, message_payload=message_payload)
+    assert send_response.status_code == 200
+
+    resource_id = send_response.json()["resourceId"]
+    assert resource_id is not None, "Missing resourceId in send GPD message response"
+    original_msg_id = resource_id.replace("-", "")
+
+    callback_data = build_callback_with_original_msg_id(
+        generate_callback_data_DS_05_ACTC_compliant,
+        original_msg_id,
+        is_document=True,
+    )
+
+    cert, key = debtor_sp_mock_cert_key
+
+    callback_response = srtp_callback(
+        rtp_payload=callback_data,
+        cert_path=cert,
+        key_path=key,
+    )
+    assert callback_response.status_code == 404, (
+        f"Expected 404 (Version header should be rejected) but got {callback_response.status_code}"
+    )
+
+    get_response = get_rtp(access_token=rtp_reader_access_token, rtp_id=resource_id)
+    assert get_response.status_code == 200
+    body = get_response.json()
+    assert body["status"] == "SENT", (
+        f"RTP status must remain SENT when Version header is present, got {body['status']}"
+    )
+
+
+@allure.epic("RTP Callback")
+@allure.feature("RTP Callback - Version Header")
+@allure.story("Callback with Version header is rejected")
+@allure.title("DS_08P ACCP callback with Version header returns 404")
+@allure.tag("functional", "unhappy_path", "rtp_callback", "regression", "version_header")
+@pytest.mark.callback
+@pytest.mark.unhappy_path
+def test_rtp_callback_DS_08P_ACCP_with_version_header(
+    rtp_consumer_access_token,
+    rtp_reader_access_token,
+    activate_payer,
+    random_fiscal_code,
+    debtor_sp_mock_cert_key,
+):
+    """
+    DS_08P ACCP callback sent with the Version header must be rejected with 404.
+    The RTP must remain in ACCEPTED (transition to USER_ACCEPTED must not happen).
+
+    Flow:
+    1. Activate payer, send RTP, advance to ACCEPTED via DS_05 (without header)
+    2. Build a valid DS_08P ACCP payload
+    3. POST WITH Version header
+    4. Verify 404 is returned
+    5. Verify RTP status is still ACCEPTED
+    """
+    message_payload = generate_gpd_message_payload(fiscal_code=random_fiscal_code, operation="CREATE", status="VALID")
+
+    activation_response = activate_payer(random_fiscal_code)
+    assert activation_response.status_code == 201
+
+    send_response = send_gpd_message(access_token=rtp_consumer_access_token, message_payload=message_payload)
+    assert send_response.status_code == 200
+
+    resource_id = send_response.json()["resourceId"]
+    assert resource_id is not None, "Missing resourceId in send GPD message response"
+    original_msg_id = resource_id.replace("-", "")
+
+    # Advance to ACCEPTED via DS_05 (without header)
+    ds05_data = build_callback_with_original_msg_id(
+        generate_callback_data_DS_05_ACTC_compliant,
+        original_msg_id,
+        is_document=True,
+    )
+    cert, key = debtor_sp_mock_cert_key
+    ds05_response = srtp_callback(
+        rtp_payload=ds05_data,
+        cert_path=cert,
+        key_path=key,
+        include_version_header=False,
+    )
+    assert ds05_response.status_code == 200, (
+        f"DS_05 setup step failed: expected 200 got {ds05_response.status_code}"
+    )
+
+    # Now send DS_08P ACCP with Version header
+    callback_data = build_callback_with_original_msg_id(
+        generate_callback_data_DS_08P_ACCP_compliant,
+        original_msg_id,
+        is_document=True,
+    )
+
+    callback_response = srtp_callback(
+        rtp_payload=callback_data,
+        cert_path=cert,
+        key_path=key,
+    )
+    assert callback_response.status_code == 404, (
+        f"Expected 404 (Version header should be rejected) but got {callback_response.status_code}"
+    )
+
+    get_response = get_rtp(access_token=rtp_reader_access_token, rtp_id=resource_id)
+    assert get_response.status_code == 200
+    body = get_response.json()
+    assert body["status"] == "ACCEPTED", (
+        f"RTP status must remain ACCEPTED when Version header is present, got {body['status']}"
+    )
+
+
+@allure.epic("RTP Callback")
+@allure.feature("RTP Callback - Version Header")
+@allure.story("Callback with Version header is rejected")
+@allure.title("DS_08N callback with Version header returns 404")
+@allure.tag("functional", "unhappy_path", "rtp_callback", "regression", "version_header")
+@pytest.mark.callback
+@pytest.mark.unhappy_path
+def test_rtp_callback_DS_08N_with_version_header(
+    rtp_consumer_access_token,
+    rtp_reader_access_token,
+    activate_payer,
+    random_fiscal_code,
+    debtor_sp_mock_cert_key,
+):
+    """
+    DS_08N callback sent with the Version header must be rejected with 404.
+    The RTP must remain in SENT (transition to REJECTED must not happen).
+
+    Flow:
+    1. Activate payer and send an RTP → resource_id
+    2. Build a valid DS_08N payload referencing the RTP
+    3. POST to callback endpoint WITH Version header
+    4. Verify 404 is returned
+    5. Verify RTP status is still SENT
+    """
+    message_payload = generate_gpd_message_payload(fiscal_code=random_fiscal_code, operation="CREATE", status="VALID")
+
+    activation_response = activate_payer(random_fiscal_code)
+    assert activation_response.status_code == 201
+
+    send_response = send_gpd_message(access_token=rtp_consumer_access_token, message_payload=message_payload)
+    assert send_response.status_code == 200
+
+    resource_id = send_response.json()["resourceId"]
+    assert resource_id is not None, "Missing resourceId in send GPD message response"
+    original_msg_id = resource_id.replace("-", "")
+
+    callback_data = build_callback_with_original_msg_id(
+        generate_callback_data_DS_08N_compliant,
+        original_msg_id,
+        is_document=True,
+    )
+
+    cert, key = debtor_sp_mock_cert_key
+
+    callback_response = srtp_callback(
+        rtp_payload=callback_data,
+        cert_path=cert,
+        key_path=key,
+    )
+    assert callback_response.status_code == 404, (
+        f"Expected 404 (Version header should be rejected) but got {callback_response.status_code}"
+    )
+
+    get_response = get_rtp(access_token=rtp_reader_access_token, rtp_id=resource_id)
+    assert get_response.status_code == 200
+    body = get_response.json()
+    assert body["status"] == "SENT", (
+        f"RTP status must remain SENT when Version header is present, got {body['status']}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# RFC callback endpoint (DS_12P, DS_12N)
+# ---------------------------------------------------------------------------
+
+
+@allure.epic("RTP Callback")
+@allure.feature("RTP Callback - Version Header")
+@allure.story("Callback with Version header is rejected")
+@allure.title("DS_12P CNCL RFC callback with Version header returns 404")
+@allure.tag("functional", "unhappy_path", "rtp_callback", "rfc", "regression", "version_header")
+@pytest.mark.callback
+@pytest.mark.unhappy_path
+def test_rfc_callback_DS_12P_CNCL_with_version_header(
+    rtp_consumer_access_token,
+    rtp_reader_access_token,
+    activate_payer,
+    random_fiscal_code,
+    debtor_sp_mock_cert_key,
+):
+    """
+    DS_12P CNCL RFC callback sent with the Version header must be rejected with 404.
+    The RTP must remain in RFC_SENT (transition to CANCELLED must not happen).
+
+    Flow:
+    1. Activate payer, send RTP, trigger cancel via GPD DELETE → RFC_SENT
+    2. Build a valid DS_12P CNCL payload
+    3. POST to RFC callback endpoint WITH Version header
+    4. Verify 404 is returned
+    5. Verify RTP status is still RFC_SENT
+    """
+    message_payload = generate_gpd_message_payload(fiscal_code=random_fiscal_code, operation="CREATE", status="VALID")
+
+    activation_response = activate_payer(random_fiscal_code)
+    assert activation_response.status_code == 201
+
+    send_response = send_gpd_message(access_token=rtp_consumer_access_token, message_payload=message_payload)
+    assert send_response.status_code == 200
+
+    resource_id = send_response.json()["resourceId"]
+    assert resource_id is not None, "Missing resourceId in send GPD message response"
+    original_msg_id = resource_id.replace("-", "")
+
+    delete_payload = generate_gpd_delete_message_payload(msg_id=message_payload["id"], iuv=message_payload["iuv"])
+    cancel_response = send_gpd_message(access_token=rtp_consumer_access_token, message_payload=delete_payload)
+    assert cancel_response.status_code == 200, (
+        f"Error cancelling RTP via DELETE, got {cancel_response.status_code}"
+    )
+
+    callback_data = generate_callback_data_DS_12P_CNCL_compliant(
+        resource_id=resource_id,
+        original_msg_id=original_msg_id,
+    )
+
+    cert, key = debtor_sp_mock_cert_key
+
+    callback_response = srtp_rfc_callback(
+        rtp_payload=callback_data,
+        cert_path=cert,
+        key_path=key,
+    )
+    assert callback_response.status_code == 404, (
+        f"Expected 404 (Version header should be rejected) but got {callback_response.status_code}"
+    )
+
+    get_response = get_rtp(access_token=rtp_reader_access_token, rtp_id=resource_id)
+    assert get_response.status_code == 200
+    body = get_response.json()
+    assert body["status"] == "RFC_SENT", (
+        f"RTP status must remain RFC_SENT when Version header is present, got {body['status']}"
+    )
+
+
+@allure.epic("RTP Callback")
+@allure.feature("RTP Callback - Version Header")
+@allure.story("Callback with Version header is rejected")
+@allure.title("DS_12N RJCR RFC callback with Version header returns 404")
+@allure.tag("functional", "unhappy_path", "rtp_callback", "rfc", "regression", "version_header")
+@pytest.mark.callback
+@pytest.mark.unhappy_path
+def test_rfc_callback_DS_12N_RJCR_with_version_header(
+    rtp_consumer_access_token,
+    rtp_reader_access_token,
+    activate_payer,
+    random_fiscal_code,
+    debtor_sp_mock_cert_key,
+):
+    """
+    DS_12N RJCR RFC callback sent with the Version header must be rejected with 404.
+    The RTP must remain in RFC_SENT (transition to ERROR_CANCEL must not happen).
+
+    Flow:
+    1. Activate payer, send RTP, trigger cancel via GPD DELETE → RFC_SENT
+    2. Build a valid DS_12N RJCR payload
+    3. POST to RFC callback endpoint WITH Version header
+    4. Verify 404 is returned
+    5. Verify RTP status is still RFC_SENT
+    """
+    message_payload = generate_gpd_message_payload(fiscal_code=random_fiscal_code, operation="CREATE", status="VALID")
+
+    activation_response = activate_payer(random_fiscal_code)
+    assert activation_response.status_code == 201
+
+    send_response = send_gpd_message(access_token=rtp_consumer_access_token, message_payload=message_payload)
+    assert send_response.status_code == 200
+
+    resource_id = send_response.json()["resourceId"]
+    assert resource_id is not None, "Missing resourceId in send GPD message response"
+    original_msg_id = resource_id.replace("-", "")
+
+    delete_payload = generate_gpd_delete_message_payload(msg_id=message_payload["id"], iuv=message_payload["iuv"])
+    cancel_response = send_gpd_message(access_token=rtp_consumer_access_token, message_payload=delete_payload)
+    assert cancel_response.status_code == 200, (
+        f"Error cancelling RTP via DELETE, got {cancel_response.status_code}"
+    )
+
+    callback_data = generate_callback_data_DS_12N_RJCR_compliant(
+        resource_id=resource_id,
+        original_msg_id=original_msg_id,
+    )
+
+    cert, key = debtor_sp_mock_cert_key
+
+    callback_response = srtp_rfc_callback(
+        rtp_payload=callback_data,
+        cert_path=cert,
+        key_path=key,
+    )
+    assert callback_response.status_code == 404, (
+        f"Expected 404 (Version header should be rejected) but got {callback_response.status_code}"
+    )
+
+    get_response = get_rtp(access_token=rtp_reader_access_token, rtp_id=resource_id)
+    assert get_response.status_code == 200
+    body = get_response.json()
+    assert body["status"] == "RFC_SENT", (
+        f"RTP status must remain RFC_SENT when Version header is present, got {body['status']}"
+    )

--- a/functional-tests/tests/callbacks/test_RTP_callback_with_version_header.py
+++ b/functional-tests/tests/callbacks/test_RTP_callback_with_version_header.py
@@ -46,18 +46,22 @@ from utils.dataset_gpd_message import generate_gpd_delete_message_payload, gener
 @pytest.mark.unhappy_path
 def test_rtp_callback_DS_04b_with_version_header(
     rtp_consumer_access_token,
+    rtp_reader_access_token,
     activate_payer,
     random_fiscal_code,
     debtor_sp_mock_cert_key,
 ):
     """
     DS_04b callback sent with the Version header must be rejected with 404.
+    The RTP state must be unchanged.
 
     Flow:
     1. Activate payer and send an RTP → resource_id
-    2. Build a valid DS_04b payload referencing the RTP
-    3. POST to callback endpoint WITH Version header
-    4. Verify 404 is returned
+    2. Capture current RTP status
+    3. Build a valid DS_04b payload referencing the RTP
+    4. POST to callback endpoint WITH Version header
+    5. Verify 404 is returned
+    6. Verify RTP status is unchanged
     """
     message_payload = generate_gpd_message_payload(fiscal_code=random_fiscal_code, operation="CREATE", status="VALID")
 
@@ -71,6 +75,10 @@ def test_rtp_callback_DS_04b_with_version_header(
     assert resource_id is not None, "Missing resourceId in send GPD message response"
     original_msg_id = resource_id.replace("-", "")
 
+    pre_callback_response = get_rtp(access_token=rtp_reader_access_token, rtp_id=resource_id)
+    assert pre_callback_response.status_code == 200
+    initial_status = pre_callback_response.json()["status"]
+
     callback_data = build_callback_with_original_msg_id(
         generate_callback_data_DS_04b_compliant,
         original_msg_id,
@@ -83,9 +91,16 @@ def test_rtp_callback_DS_04b_with_version_header(
         rtp_payload=callback_data,
         cert_path=cert,
         key_path=key,
+        include_version_header=True,
     )
     assert callback_response.status_code == 404, (
         f"Expected 404 (Version header should be rejected) but got {callback_response.status_code}"
+    )
+
+    post_callback_response = get_rtp(access_token=rtp_reader_access_token, rtp_id=resource_id)
+    assert post_callback_response.status_code == 200
+    assert post_callback_response.json()["status"] == initial_status, (
+        f"RTP status must be unchanged when Version header is present, got {post_callback_response.json()['status']}"
     )
 
 
@@ -138,6 +153,7 @@ def test_rtp_callback_DS_05_ACTC_with_version_header(
         rtp_payload=callback_data,
         cert_path=cert,
         key_path=key,
+        include_version_header=True,
     )
     assert callback_response.status_code == 404, (
         f"Expected 404 (Version header should be rejected) but got {callback_response.status_code}"
@@ -216,6 +232,7 @@ def test_rtp_callback_DS_08P_ACCP_with_version_header(
         rtp_payload=callback_data,
         cert_path=cert,
         key_path=key,
+        include_version_header=True,
     )
     assert callback_response.status_code == 404, (
         f"Expected 404 (Version header should be rejected) but got {callback_response.status_code}"
@@ -278,6 +295,7 @@ def test_rtp_callback_DS_08N_with_version_header(
         rtp_payload=callback_data,
         cert_path=cert,
         key_path=key,
+        include_version_header=True,
     )
     assert callback_response.status_code == 404, (
         f"Expected 404 (Version header should be rejected) but got {callback_response.status_code}"
@@ -350,6 +368,7 @@ def test_rfc_callback_DS_12P_CNCL_with_version_header(
         rtp_payload=callback_data,
         cert_path=cert,
         key_path=key,
+        include_version_header=True,
     )
     assert callback_response.status_code == 404, (
         f"Expected 404 (Version header should be rejected) but got {callback_response.status_code}"
@@ -417,6 +436,7 @@ def test_rfc_callback_DS_12N_RJCR_with_version_header(
         rtp_payload=callback_data,
         cert_path=cert,
         key_path=key,
+        include_version_header=True,
     )
     assert callback_response.status_code == 404, (
         f"Expected 404 (Version header should be rejected) but got {callback_response.status_code}"


### PR DESCRIPTION
### Description

This PR updates the existing callback test suite to remove the `Version` HTTP header from
requests and adds a new regression suite to verify that requests carrying the `Version`
header are rejected.

### List of changes

- Updated all existing callback tests (DS_04, DS_05, DS_08, DS_12P, DS_12N) to send
  requests without the `Version` header.
- Added `include_version_header` parameter to `srtp_callback` and `srtp_rfc_callback`
  API helpers to support both behaviors.
- Added `test_RTP_callback_with_version_header.py`: a new regression suite covering all
  DS types that verifies callbacks sent with the `Version` header are rejected with `404`
  and do not trigger any RTP state transition.

### Motivation and context

Existing tests were updated to align with a backend change on callback endpoints.
The regression suite detects if versioned routing is accidentally re-introduced in future
deployments.

### Aggregation level

- [ ] Test case
- [x] Test suite

### Test type

- [x] Functional test
- [ ] Bdd test
- [ ] Performance
- [ ] End to end

### Type of changes

- [x] Add new test case/suite
- [x] Modify existing test case/suite

### Test Results

- [x] Success
- [x] Failure
- [ ] Poor performance
- [ ] Good performance

### Did you update secrets accordingly?

- [ ] Yes
- [x] Not needed
- [ ] No

### Did you update dependencies accordingly?

- [ ] Yes
- [x] Not needed
