### PR TITLE
feat: [SRTP-1980] add forbidden 403 test

### DIFF
--- a/functional-tests/tests/activation/test_debtor_activation_payer_status.py
+++ b/functional-tests/tests/activation/test_debtor_activation_payer_status.py
@@ -232,7 +232,7 @@ def test_get_activation_status_unauthorized():
 @allure.epic("Debtor Activation")
 @allure.feature("Payer Status")
 @allure.story("Get Activation Status by Fiscal Code")
-@allure.title("Token without read_rtp_activation or read_rtp_all role returns 403 Forbidden")
+@allure.title("Token without read_rtp_activations or read_rtp_all role returns 403 Forbidden")
 @allure.tag("functional", "unhappy_path", "activation", "payer_status", "security")
 @pytest.mark.activation
 @pytest.mark.unhappy_path

--- a/functional-tests/tests/activation/test_debtor_activation_payer_status.py
+++ b/functional-tests/tests/activation/test_debtor_activation_payer_status.py
@@ -232,6 +232,19 @@ def test_get_activation_status_unauthorized():
 @allure.epic("Debtor Activation")
 @allure.feature("Payer Status")
 @allure.story("Get Activation Status by Fiscal Code")
+@allure.title("Token without read_rtp_activation or read_rtp_all role returns 403 Forbidden")
+@allure.tag("functional", "unhappy_path", "activation", "payer_status", "security")
+@pytest.mark.activation
+@pytest.mark.unhappy_path
+def test_get_activation_status_forbidden_no_role(pagopa_service_providers_registry_token, random_fiscal_code):
+    """A valid token that carries neither read_rtp_activations nor read_rtp_all must be rejected with 403."""
+    res = get_activation_status_by_fiscal_code(pagopa_service_providers_registry_token, random_fiscal_code)
+    assert res.status_code == 403, f"Expected 403 Forbidden but got {res.status_code}: {res.text}"
+
+
+@allure.epic("Debtor Activation")
+@allure.feature("Payer Status")
+@allure.story("Get Activation Status by Fiscal Code")
 @allure.title("Querying activation status with an invalid payerId format returns 400")
 @allure.tag("functional", "unhappy_path", "activation", "payer_status")
 @pytest.mark.activation


### PR DESCRIPTION
Description

This PR adds a missing negative test case to the GET /activations/payer/{payerId}/status test suite. The endpoint requires either the read_rtp_activations or read_rtp_all role. While the 401 (unauthenticated) and 400 (invalid format) scenarios were already covered, no test verified that a valid but insufficiently privileged token is rejected with 403 Forbidden.

List of changes

 - Added test_get_activation_status_forbidden_no_role to functional-tests/tests/activation/test_debtor_activation_payer_status.py, using pagopa_service_providers_registry_token (which only holds the read_service_registry role) to assert a 403 response.

Motivation and context

The authorization layer for this endpoint enforces two specific roles. Without a test for the forbidden case, a regression that accidentally grants access to unprivileged clients would go undetected. This change closes that gap and completes the HTTP status coverage: 200 → 400 → 401 → 403.

Aggregation level

 - [X]  Test case
 - [ ]  Test suite

Test type

 - [X]  Functional test
 - [ ]  Bdd test
 - [ ]  Performance
 - [ ]  End to end

Type of changes

 - [ ]  Add new test case/suite
 - [X]  Modify existing test case/suite

Test Results

 - [ ]  Success
 - [x]  Failure
 - [ ]  Poor performance
 - [ ]  Good performance

Did you update secrets accordingly?

 - [ ]  Yes
 - [X]  Not needed
 - [ ]  No

Did you update dependencies accordingly?

 - [ ]  Yes
 - [X]  Not needed

Other information

No new fixtures or secrets are required. The pagopa_service_providers_registry_token fixture already exists in conftest.py.
