### PR TITLE
feat: [SRTP-650] manage gh pages artifact cleanup

### DIFF
--- a/.github/workflows/cleanup-old-reports.yml
+++ b/.github/workflows/cleanup-old-reports.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   cleanup:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout cleanup script
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 #v4.2.0
@@ -28,6 +30,16 @@ jobs:
           ref: gh-pages
           path: gh-pages
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Ensure .gitignore exists on gh-pages
+        run: |
+          if [ ! -f gh-pages/.gitignore ]; then
+            echo ".DS_Store" > gh-pages/.gitignore
+            echo "Thumbs.db" >> gh-pages/.gitignore
+          elif ! grep -q ".DS_Store" gh-pages/.gitignore; then
+            echo ".DS_Store" >> gh-pages/.gitignore
+            echo "Thumbs.db" >> gh-pages/.gitignore
+          fi
 
       - name: Cleanup old reports
         run: |

--- a/.github/workflows/cleanup-old-reports.yml
+++ b/.github/workflows/cleanup-old-reports.yml
@@ -10,6 +10,10 @@ on:
         required: false
         default: '20'
 
+concurrency:
+  group: cleanup-old-reports
+  cancel-in-progress: true
+
 jobs:
   cleanup:
     runs-on: ubuntu-latest
@@ -33,13 +37,13 @@ jobs:
 
       - name: Ensure .gitignore exists on gh-pages
         run: |
-          if [ ! -f gh-pages/.gitignore ]; then
-            echo ".DS_Store" > gh-pages/.gitignore
-            echo "Thumbs.db" >> gh-pages/.gitignore
-          elif ! grep -q ".DS_Store" gh-pages/.gitignore; then
-            echo ".DS_Store" >> gh-pages/.gitignore
-            echo "Thumbs.db" >> gh-pages/.gitignore
-          fi
+          grep -qF '.DS_Store' gh-pages/.gitignore 2>/dev/null || echo '.DS_Store' >> gh-pages/.gitignore
+          grep -qF 'Thumbs.db' gh-pages/.gitignore 2>/dev/null || echo 'Thumbs.db' >> gh-pages/.gitignore
+
+      - name: Setup Python
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b #v5.3.0
+        with:
+          python-version: 3.x
 
       - name: Cleanup old reports
         run: |

--- a/.github/workflows/cleanup-old-reports.yml
+++ b/.github/workflows/cleanup-old-reports.yml
@@ -1,0 +1,47 @@
+name: Cleanup Old Reports
+
+on:
+  schedule:
+    - cron: '0 2 * * *'  # Every night at 2 AM UTC
+  workflow_dispatch:
+    inputs:
+      keep:
+        description: Number of most recent report runs to keep
+        required: false
+        default: '20'
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout cleanup script
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 #v4.2.0
+        with:
+          sparse-checkout: |
+            cleanup-old-reports.py
+          sparse-checkout-cone-mode: false
+          path: source
+
+      - name: Checkout gh-pages
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 #v4.2.0
+        with:
+          ref: gh-pages
+          path: gh-pages
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cleanup old reports
+        run: |
+          python3 source/cleanup-old-reports.py ${{ github.event.inputs.keep || '20' }} gh-pages
+
+      - name: Commit and push if changed
+        run: |
+          cd gh-pages
+          git config user.name 'rtp-gh-bot'
+          git config user.email 'rtp-github-bot@pagopa.it'
+          git add -A
+          if git diff --staged --quiet; then
+            echo "Nothing to delete, gh-pages is already clean"
+          else
+            git commit -m "chore: cleanup report runs, keeping last ${{ github.event.inputs.keep || '20' }}"
+            git push origin gh-pages
+          fi

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: '0 6 * * *'  # Scheduled every day at 08:00 UTC
+    - cron: '0 6 * * *'  # Scheduled every day at 07:00 CET / 08:00 CEST
   workflow_dispatch: # Allows manual run
     inputs:
       Functional:

--- a/cleanup-old-reports.py
+++ b/cleanup-old-reports.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""
+Remove Allure report run directories beyond the last N runs from gh-pages.
+
+Keeps the N most recent numbered directories (by run number) and deletes
+the rest, including corresponding subdirectories (functional/, bdd/, ux/, contract/).
+
+Usage:
+    python cleanup-old-reports.py [keep=20] [gh-pages-path=.]
+"""
+import shutil
+import sys
+from pathlib import Path
+
+REPORT_SUBDIRS = ['functional', 'bdd', 'ux', 'contract']
+
+keep = int(sys.argv[1]) if len(sys.argv) > 1 else 20
+gh_pages = Path(sys.argv[2]) if len(sys.argv) > 2 else Path('.')
+
+run_dirs = sorted(
+    [d for d in gh_pages.iterdir() if d.is_dir() and d.name.isdigit()],
+    key=lambda d: int(d.name),
+    reverse=True,
+)
+
+to_delete = run_dirs[keep:]
+
+if not to_delete:
+    print(f'Nothing to delete ({len(run_dirs)} run(s) found, keeping up to {keep})')
+    sys.exit(0)
+
+for run_dir in to_delete:
+    print(f'Removing run {run_dir.name}...')
+    shutil.rmtree(run_dir)
+    for sub in REPORT_SUBDIRS:
+        sub_run = gh_pages / sub / run_dir.name
+        if sub_run.exists():
+            shutil.rmtree(sub_run)
+            print(f'  Removed {sub}/{run_dir.name}')
+
+print(f'\nDone: removed {len(to_delete)} run(s), kept {min(len(run_dirs), keep)}')

--- a/cleanup-old-reports.py
+++ b/cleanup-old-reports.py
@@ -12,7 +12,7 @@ import shutil
 import sys
 from pathlib import Path
 
-REPORT_SUBDIRS = ['functional', 'bdd', 'ux', 'contract']
+REPORT_SUBDIRS = ['functional', 'bdd', 'ux', 'contract', 'aggregate']
 
 keep = int(sys.argv[1]) if len(sys.argv) > 1 else 20
 gh_pages = Path(sys.argv[2]) if len(sys.argv) > 2 else Path('.')

--- a/cleanup-old-reports.py
+++ b/cleanup-old-reports.py
@@ -3,7 +3,7 @@
 Remove Allure report run directories beyond the last N runs from gh-pages.
 
 Keeps the N most recent numbered directories (by run number) and deletes
-the rest, including corresponding subdirectories (functional/, bdd/, ux/, contract/).
+the rest, including corresponding subdirectories (functional/, bdd/, ux/, contract/, aggregate/).
 
 Usage:
     python cleanup-old-reports.py [keep=20] [gh-pages-path=.]
@@ -14,7 +14,14 @@ from pathlib import Path
 
 REPORT_SUBDIRS = ['functional', 'bdd', 'ux', 'contract', 'aggregate']
 
-keep = int(sys.argv[1]) if len(sys.argv) > 1 else 20
+try:
+    keep = int(sys.argv[1]) if len(sys.argv) > 1 else 20
+except ValueError:
+    print(f"Invalid keep value: {sys.argv[1]!r} (expected non-negative integer)", file=sys.stderr)
+    sys.exit(2)
+if keep < 0:
+    print(f"Invalid keep value: {keep} (expected non-negative integer)", file=sys.stderr)
+    sys.exit(2)
 gh_pages = Path(sys.argv[2]) if len(sys.argv) > 2 else Path('.')
 
 run_dirs = sorted(
@@ -34,8 +41,11 @@ for run_dir in to_delete:
     shutil.rmtree(run_dir)
     for sub in REPORT_SUBDIRS:
         sub_run = gh_pages / sub / run_dir.name
-        if sub_run.exists():
+        if sub_run.is_dir():
             shutil.rmtree(sub_run)
+            print(f'  Removed {sub}/{run_dir.name}')
+        elif sub_run.exists():
+            sub_run.unlink()
             print(f'  Removed {sub}/{run_dir.name}')
 
 print(f'\nDone: removed {len(to_delete)} run(s), kept {min(len(run_dirs), keep)}')


### PR DESCRIPTION
### Description

This PR introduces an automated cleanup mechanism for Allure test reports published on GitHub Pages. Over time, the `gh-pages` branch accumulates a large number of run directories (one per CI execution), which can cause the branch to grow unboundedly. The new workflow runs nightly and trims old report runs, keeping only the N most recent ones (default: 20).

### List of changes

- **Added** `.github/workflows/cleanup-old-reports.yml`: a new scheduled workflow (runs nightly at 02:00 UTC, also triggerable manually) that checks out both the main branch (for the cleanup script) and the `gh-pages` branch, runs the Python cleanup script, and pushes the result back to `gh-pages`.
- **Added** `cleanup-old-reports.py`: a Python script that identifies all numbered run directories on `gh-pages`, keeps the N most recent (configurable via input, default 20), and deletes the rest — including corresponding subdirectories under `functional/`, `bdd/`, `ux/`, `contract/`, and `aggregate/`.
- **Updated** `.github/workflows/run_tests.yml`: clarified the cron comment to correctly reflect both CET and CEST offsets (`07:00 CET / 08:00 CEST`).

### Motivation and context

The `gh-pages` branch hosts Allure HTML reports for every test run. Without a cleanup policy, old runs accumulate indefinitely, increasing the branch size and GitHub Pages build times. This PR adds a lightweight nightly janitor that keeps the branch manageable by retaining only the most recent 20 runs by default. The number of runs to keep is configurable via `workflow_dispatch` input for ad-hoc cleanup.

### Aggregation level

- [ ] Test case
- [ ] Test suite

### Test type

- [ ] Functional test
- [ ] Bdd test
- [ ] Performance
- [ ] End to end
- [ ] Performance

### Type of changes

- [ ] Add new test case/suite
- [ ] Modify existing test case/suite

### Test Results

- [ ] Success
- [ ] Failure
- [ ] Poor performance
- [ ] Good performance

### Did you update secrets accordingly?

- [ ] Yes
  - [ ] `.secrets_template.yaml`
  - [ ] Pipelines' secure file
  - [ ] Confluence
- [x] Not needed
- [ ] No (_please provide further information_)

### Did you update dependencies accordingly?

- [ ] Yes (which requirements.txt did you update?)
- [x] Not needed

### Other information

The cleanup script uses only Python standard library modules (`shutil`, `sys`, `pathlib`) — no additional dependencies required. The workflow uses sparse checkout to pull only the script from the default branch, keeping the checkout minimal.
