### PR TITLE
fix: [SRTP-2014] Make empty Payer Id test return 404 for GET Payer Status API

### DIFF
--- a/functional-tests/tests/activation/test_debtor_activation_payer_status.py
+++ b/functional-tests/tests/activation/test_debtor_activation_payer_status.py
@@ -5,8 +5,8 @@ by fiscal code or VAT number) is currently active in the RTP system.
 The ``payerId`` is passed as a **path parameter**.
 
 Privacy rule: the response is deliberately indistinguishable between "not found" and
-"active under a different Service Provider" — both cases return ``{ "isActive": false }``
-— to avoid leaking cross-SP information to competitors.
+"active under a different Service Provider" - both cases return ``{ "isActive": false }``
+- to avoid leaking cross-SP information to competitors.
 
 Authorization roles:
 - ``read_rtp_activations``: reads only activations whose ``serviceProviderDebtor`` matches
@@ -21,7 +21,7 @@ and is extended with structural edge cases from the Italian CF/PIVA specificatio
 - **Case**: lowercase and mixed-case CFs (only uppercase alphanumeric is valid).
 - **Month codes**: valid set is A B C D E H L M P R S T.  F and G (between valid E and H)
   and U (outside range) are the most common off-by-one mistakes.
-- **Birth day**: male range 01–31, female range 41–71.  Day 00, 32, 40 (dead zone), and 72
+- **Birth day**: male range 01-31, female range 41-71.  Day 00, 32, 40 (dead zone), and 72
   are the relevant boundary violations.
 - **Special characters**: ``!``, embedded space, leading/trailing whitespace (17 chars → length
   error), non-numeric VAT-like string, all-zeros (10 digits).
@@ -123,8 +123,8 @@ def test_get_activation_status_role_comparison_cross_service_provider(
 ):
     """
     Payer activated under SP A.
-    - SP B (read_rtp_activations): isActive must be false — privacy rule hides cross-SP activation.
-    - Admin (read_rtp_all): isActive must be true — role grants visibility across all SPs.
+    - SP B (read_rtp_activations): isActive must be false - privacy rule hides cross-SP activation.
+    - Admin (read_rtp_all): isActive must be true - role grants visibility across all SPs.
     Same payer, same endpoint, different roles → different results.
     """
     _activation_id, debtor_fc = make_activation()

--- a/functional-tests/tests/activation/test_debtor_activation_payer_status.py
+++ b/functional-tests/tests/activation/test_debtor_activation_payer_status.py
@@ -28,7 +28,7 @@ and is extended with structural edge cases from the Italian CF/PIVA specificatio
 - **EU VAT prefix**: ``IT`` + 11 digits → 13 chars → length error (common client mistake).
 - **Checksum probe**: syntactically valid CF with wrong control character.  This case acts
   as a TDD sentinel: it stays red until the backend enforces checksum validation.
-- **Empty string**: empty path segment → 400 (or 404 depending on routing).
+- **Empty string**: empty path segment → 404 (routing resolves it before validation).
 """
 
 import allure

--- a/functional-tests/tests/activation/test_debtor_activation_payer_status.py
+++ b/functional-tests/tests/activation/test_debtor_activation_payer_status.py
@@ -258,3 +258,16 @@ def test_get_activation_status_invalid_payer_id_format(debtor_service_provider_t
     """
     res = get_activation_status_by_fiscal_code(debtor_service_provider_token_a, invalid_payer_id)
     assert res.status_code == 400, f"[{description}] Expected 400 but got {res.status_code}: {res.text}"
+
+
+@allure.epic("Debtor Activation")
+@allure.feature("Payer Status")
+@allure.story("Get Activation Status by Fiscal Code")
+@allure.title("Querying activation status with an empty payerId returns 404")
+@allure.tag("functional", "unhappy_path", "activation", "payer_status")
+@pytest.mark.activation
+@pytest.mark.unhappy_path
+def test_get_activation_status_empty_payer_id(debtor_service_provider_token_a):
+    """Querying activation status with an empty payerId must be rejected with 404."""
+    res = get_activation_status_by_fiscal_code(debtor_service_provider_token_a, "")
+    assert res.status_code == 404, f"Expected 404 Not Found but got {res.status_code}: {res.text}"

--- a/utils/dataset_payer_id_invalid.py
+++ b/utils/dataset_payer_id_invalid.py
@@ -8,7 +8,7 @@ a 400 response.  Import it wherever parametrized negative-path assertions on
 Validation rules enforced by the backend:
 
 - **Fiscal code**: 16 uppercase alphanumeric characters, valid month code
-  (A B C D E H L M P R S T), birth day in range 01–31 (male) or 41–71 (female),
+  (A B C D E H L M P R S T), birth day in range 01-31 (male) or 41-71 (female),
   and a correct Luhn-style control character.
 - **VAT number**: exactly 11 decimal digits.
 
@@ -16,11 +16,11 @@ Edge-case rationale
 -------------------
 - **Month codes**: the valid set is non-contiguous.  F and G (between valid E and H)
   and U are the most common off-by-one mistakes in validators.
-- **Birth day dead zone**: 32–40 is always invalid (male max = 31, female min = 41).
-- **EU VAT prefix**: ``IT`` + 11 digits produces a 13-char string — a common client
+- **Birth day dead zone**: 32-40 is always invalid (male max = 31, female min = 41).
+- **EU VAT prefix**: ``IT`` + 11 digits produces a 13-char string - a common client
   mistake that must be rejected on length grounds before any digit check.
 - **Checksum probe** (``cf_wrong_checksum``): syntactically valid CF with a wrong
-  control character.  Acts as a TDD sentinel — stays red until the backend enforces
+  control character.  Acts as a TDD sentinel - stays red until the backend enforces
   checksum validation.
 """
 

--- a/utils/dataset_payer_id_invalid.py
+++ b/utils/dataset_payer_id_invalid.py
@@ -46,5 +46,4 @@ INVALID_PAYER_IDS = [
     ("all_zeros_10_digits", "0000000000"),
     ("vat_with_eu_it_prefix", "IT12345678903"),
     ("cf_wrong_checksum", "RSSMRA85T10A562T"),
-    ("empty_string", ""),
 ]


### PR DESCRIPTION
### Description

Adds a dedicated test case for querying the GET Payer Status API with an empty `payerId`, and fixes the existing invalid-format parametrized suite to exclude that case.

---

### List of changes

- Added `test_get_activation_status_empty_payer_id`: asserts HTTP 404 when `payerId` is an empty string
- Removed `("empty_string", "")` from `INVALID_PAYER_IDS` dataset (was asserting 400; actual behaviour is 404 via routing)
- Updated module docstrings to reflect correct expected status for empty `payerId`

---

### Motivation and context

An empty `payerId` path segment is resolved by the router before validation runs, producing a 404 rather than a 400. The empty-string case was previously lumped into the 400-asserting parametrized suite, causing a misleading test. This change aligns test expectations with actual API behaviour.

---

### Aggregation level

- [x] Test case
- [ ] Test suite

---

### Test type

- [x] Functional test
- [ ] Bdd test
- [ ] Performance
- [ ] End to end

---

### Type of changes

- [x] Add new test case/suite
- [x] Modify existing test case/suite

---

### Test Results

- [x] Success
- [ ] Failure
- [ ] Poor performance
- [ ] Good performance

---

### Did you update secrets accordingly?

- [x] Not needed

---

### Did you update dependencies accordingly?

- [x] Not needed

---

### Other information