### PR TITLE
fix: [SRTP-2049] update activation unhappy path tests

### DIFF
--- a/functional-tests/tests/activation/test_debtor_activation_create.py
+++ b/functional-tests/tests/activation/test_debtor_activation_create.py
@@ -11,12 +11,6 @@ from utils.dataset_payer_id_invalid import INVALID_PAYER_IDS
 from utils.http_utils import extract_id_from_location
 from utils.regex_utils import uuidv4_pattern
 
-# The activation endpoint does not yet enforce fiscal code checksum validation
-# (an activation with a syntactically valid but wrong-checksum CF succeeds with 201),
-# so the "cf_wrong_checksum" TDD sentinel from INVALID_PAYER_IDS is excluded here.
-INVALID_FISCAL_CODE_IDS = [case for case in INVALID_PAYER_IDS if case[0] != "cf_wrong_checksum"]
-
-
 @allure.epic("Debtor Activation")
 @allure.feature("Activation")
 @allure.story("Debtor activation")
@@ -170,7 +164,7 @@ def test_activate_debtor_with_vat_number(debtor_service_provider_token_a, activa
 @pytest.mark.auth
 @pytest.mark.activation
 @pytest.mark.unhappy_path
-@pytest.mark.parametrize("description,invalid_payer_id", INVALID_FISCAL_CODE_IDS)
+@pytest.mark.parametrize("description,invalid_payer_id", INVALID_PAYER_IDS)
 def test_cannot_activate_debtor_invalid_fiscal_code_format(
     debtor_service_provider_token_a, description, invalid_payer_id
 ):

--- a/functional-tests/tests/activation/test_debtor_activation_create.py
+++ b/functional-tests/tests/activation/test_debtor_activation_create.py
@@ -64,6 +64,11 @@ def test_activate_debtor_already_active_on_another_service_provider_triggers_tak
     otp = extract_id_from_location(res_b.headers.get("Location"))
     assert otp is not None, "Missing/invalid Location header (expected OTP for takeover trigger)"
 
+    body = res_b.json()
+    assert isinstance(body.get("errors"), list) and body["errors"], "Expected non-empty 'errors' list in 409 response"
+    assert body["errors"][0]["code"] == "01031006E"
+    assert body["errors"][0]["description"] == "User is already active"
+
 
 @allure.epic("Debtor Activation")
 @allure.feature("Activation")
@@ -164,8 +169,68 @@ def test_cannot_activate_debtor_lower_fiscal_code(debtor_service_provider_token_
         debtor_service_provider_token_a, random_fiscal_code.lower(), secrets.debtor_service_provider.service_provider_id
     )
     assert res.status_code == 400
-    assert res.json()["errors"][0]["code"] == "Pattern.activationReqDtoMono.payer.fiscalCode"
-    assert res.json()["errors"][0]["description"].startswith("payer.fiscalCode must match")
+    assert res.json()["errors"][0]["code"] == "01021002E"
+    assert res.json()["errors"][0]["description"] == "Invalid fiscal code format."
+
+
+@allure.epic("Debtor Activation")
+@allure.feature("Activation")
+@allure.story("Debtor activation")
+@allure.title("The activation request must contain a validly formatted Service Provider ID")
+@allure.tag("functional", "unhappy_path", "activation", "debtor_activation")
+@pytest.mark.auth
+@pytest.mark.activation
+@pytest.mark.unhappy_path
+def test_cannot_activate_debtor_lower_rtp_sp_id(debtor_service_provider_token_a, random_fiscal_code):
+
+    res = activate(
+        debtor_service_provider_token_a,
+        random_fiscal_code,
+        secrets.debtor_service_provider.service_provider_id.lower(),
+    )
+    assert res.status_code == 400
+    assert res.json()["errors"][0]["code"] == "01021003E"
+    assert res.json()["errors"][0]["description"] == "Invalid RTP Service Provider ID format."
+
+
+@allure.epic("Debtor Activation")
+@allure.feature("Activation")
+@allure.story("Debtor activation")
+@allure.title("The activation request must contain a fiscal code of valid length")
+@allure.tag("functional", "unhappy_path", "activation", "debtor_activation")
+@pytest.mark.auth
+@pytest.mark.activation
+@pytest.mark.unhappy_path
+def test_cannot_activate_debtor_short_fiscal_code(debtor_service_provider_token_a, random_fiscal_code):
+
+    res = activate(
+        debtor_service_provider_token_a,
+        random_fiscal_code[:5],
+        secrets.debtor_service_provider.service_provider_id,
+    )
+    assert res.status_code == 400
+    assert res.json()["errors"][0]["code"] == "01021002E"
+    assert res.json()["errors"][0]["description"] == "Invalid fiscal code format."
+
+
+@allure.epic("Debtor Activation")
+@allure.feature("Activation")
+@allure.story("Debtor activation")
+@allure.title("The activation request must contain a Service Provider ID of valid length")
+@allure.tag("functional", "unhappy_path", "activation", "debtor_activation")
+@pytest.mark.auth
+@pytest.mark.activation
+@pytest.mark.unhappy_path
+def test_cannot_activate_debtor_short_rtp_sp_id(debtor_service_provider_token_a, random_fiscal_code):
+
+    res = activate(
+        debtor_service_provider_token_a,
+        random_fiscal_code,
+        secrets.debtor_service_provider.service_provider_id[:3],
+    )
+    assert res.status_code == 400
+    assert res.json()["errors"][0]["code"] == "01021003E"
+    assert res.json()["errors"][0]["description"] == "Invalid RTP Service Provider ID format."
 
 
 @allure.epic("Debtor Activation")

--- a/functional-tests/tests/activation/test_debtor_activation_create.py
+++ b/functional-tests/tests/activation/test_debtor_activation_create.py
@@ -6,8 +6,14 @@ import pytest
 from api.debtor_activation_api import activate, get_activation_by_payer_id
 from config.configuration import config, secrets
 from utils.activation_helpers import activate_with_sp_a, activate_with_sp_b
+from utils.dataset_payer_id_invalid import INVALID_PAYER_IDS
 from utils.http_utils import extract_id_from_location
 from utils.regex_utils import uuidv4_pattern
+
+# The activation endpoint does not yet enforce fiscal code checksum validation
+# (an activation with a syntactically valid but wrong-checksum CF succeeds with 201),
+# so the "cf_wrong_checksum" TDD sentinel from INVALID_PAYER_IDS is excluded here.
+INVALID_FISCAL_CODE_IDS = [case for case in INVALID_PAYER_IDS if case[0] != "cf_wrong_checksum"]
 
 
 @allure.epic("Debtor Activation")
@@ -158,17 +164,21 @@ def test_activate_debtor_with_vat_number(debtor_service_provider_token_a, activa
 @allure.epic("Debtor Activation")
 @allure.feature("Activation")
 @allure.story("Debtor activation")
-@allure.title("The activation request must contain lower case fiscal code")
+@allure.title("The activation request must contain a validly formatted fiscal code")
 @allure.tag("functional", "unhappy_path", "activation", "debtor_activation")
 @pytest.mark.auth
 @pytest.mark.activation
 @pytest.mark.unhappy_path
-def test_cannot_activate_debtor_lower_fiscal_code(debtor_service_provider_token_a, random_fiscal_code):
+@pytest.mark.parametrize("description,invalid_payer_id", INVALID_FISCAL_CODE_IDS)
+def test_cannot_activate_debtor_invalid_fiscal_code_format(
+    debtor_service_provider_token_a, description, invalid_payer_id
+):
+    """Each entry in ``INVALID_PAYER_IDS`` (see dataset docstring) must be rejected with 400."""
 
     res = activate(
-        debtor_service_provider_token_a, random_fiscal_code.lower(), secrets.debtor_service_provider.service_provider_id
+        debtor_service_provider_token_a, invalid_payer_id, secrets.debtor_service_provider.service_provider_id
     )
-    assert res.status_code == 400
+    assert res.status_code == 400, f"[{description}] Expected 400 but got {res.status_code}: {res.text}"
     assert res.json()["errors"][0]["code"] == "01021002E"
     assert res.json()["errors"][0]["description"] == "Invalid fiscal code format."
 
@@ -191,26 +201,6 @@ def test_cannot_activate_debtor_lower_rtp_sp_id(debtor_service_provider_token_a,
     assert res.status_code == 400
     assert res.json()["errors"][0]["code"] == "01021003E"
     assert res.json()["errors"][0]["description"] == "Invalid RTP Service Provider ID format." 
-
-
-@allure.epic("Debtor Activation")
-@allure.feature("Activation")
-@allure.story("Debtor activation")
-@allure.title("The activation request must contain a fiscal code of valid length")
-@allure.tag("functional", "unhappy_path", "activation", "debtor_activation")
-@pytest.mark.auth
-@pytest.mark.activation
-@pytest.mark.unhappy_path
-def test_cannot_activate_debtor_short_fiscal_code(debtor_service_provider_token_a, random_fiscal_code):
-
-    res = activate(
-        debtor_service_provider_token_a,
-        random_fiscal_code[:5],
-        secrets.debtor_service_provider.service_provider_id,
-    )
-    assert res.status_code == 400
-    assert res.json()["errors"][0]["code"] == "01021002E"
-    assert res.json()["errors"][0]["description"] == "Invalid fiscal code format."
 
 
 @allure.epic("Debtor Activation")

--- a/functional-tests/tests/activation/test_debtor_activation_create.py
+++ b/functional-tests/tests/activation/test_debtor_activation_create.py
@@ -190,7 +190,7 @@ def test_cannot_activate_debtor_lower_rtp_sp_id(debtor_service_provider_token_a,
     )
     assert res.status_code == 400
     assert res.json()["errors"][0]["code"] == "01021003E"
-    assert res.json()["errors"][0]["description"] == "Invalid RTP Service Provider ID format."
+    assert res.json()["errors"][0]["description"] == "Invalid RTP Service Provider ID format." 
 
 
 @allure.epic("Debtor Activation")

--- a/functional-tests/tests/activation/test_debtor_activation_create.py
+++ b/functional-tests/tests/activation/test_debtor_activation_create.py
@@ -5,6 +5,7 @@ import pytest
 
 from api.debtor_activation_api import activate, get_activation_by_payer_id
 from config.configuration import config, secrets
+from utils.activation_error_codes import ActivationErrorCode
 from utils.activation_helpers import activate_with_sp_a, activate_with_sp_b
 from utils.dataset_payer_id_invalid import INVALID_PAYER_IDS
 from utils.http_utils import extract_id_from_location
@@ -72,8 +73,8 @@ def test_activate_debtor_already_active_on_another_service_provider_triggers_tak
 
     body = res_b.json()
     assert isinstance(body.get("errors"), list) and body["errors"], "Expected non-empty 'errors' list in 409 response"
-    assert body["errors"][0]["code"] == "01031006E"
-    assert body["errors"][0]["description"] == "User is already active"
+    assert body["errors"][0]["code"] == ActivationErrorCode.USER_ALREADY_ACTIVE.code
+    assert body["errors"][0]["description"] == ActivationErrorCode.USER_ALREADY_ACTIVE.description
 
 
 @allure.epic("Debtor Activation")
@@ -102,8 +103,8 @@ def test_fail_activate_debtor_two_times(debtor_service_provider_token_a, random_
 
     body = res.json()
     assert isinstance(body.get("errors"), list) and body["errors"], "Expected non-empty 'errors' list in 409 response"
-    assert body["errors"][0]["code"] == "01031006E"
-    assert body["errors"][0]["description"] == "User is already active"
+    assert body["errors"][0]["code"] == ActivationErrorCode.USER_ALREADY_ACTIVE.code
+    assert body["errors"][0]["description"] == ActivationErrorCode.USER_ALREADY_ACTIVE.description
 
 
 @allure.epic("Debtor Activation")
@@ -179,8 +180,8 @@ def test_cannot_activate_debtor_invalid_fiscal_code_format(
         debtor_service_provider_token_a, invalid_payer_id, secrets.debtor_service_provider.service_provider_id
     )
     assert res.status_code == 400, f"[{description}] Expected 400 but got {res.status_code}: {res.text}"
-    assert res.json()["errors"][0]["code"] == "01021002E"
-    assert res.json()["errors"][0]["description"] == "Invalid fiscal code format."
+    assert res.json()["errors"][0]["code"] == ActivationErrorCode.INVALID_FISCAL_CODE_FORMAT.code
+    assert res.json()["errors"][0]["description"] == ActivationErrorCode.INVALID_FISCAL_CODE_FORMAT.description
 
 
 @allure.epic("Debtor Activation")
@@ -199,8 +200,8 @@ def test_cannot_activate_debtor_lower_rtp_sp_id(debtor_service_provider_token_a,
         secrets.debtor_service_provider.service_provider_id.lower(),
     )
     assert res.status_code == 400
-    assert res.json()["errors"][0]["code"] == "01021003E"
-    assert res.json()["errors"][0]["description"] == "Invalid RTP Service Provider ID format." 
+    assert res.json()["errors"][0]["code"] == ActivationErrorCode.INVALID_SERVICE_PROVIDER_ID_FORMAT.code
+    assert res.json()["errors"][0]["description"] == ActivationErrorCode.INVALID_SERVICE_PROVIDER_ID_FORMAT.description
 
 
 @allure.epic("Debtor Activation")
@@ -219,8 +220,8 @@ def test_cannot_activate_debtor_short_rtp_sp_id(debtor_service_provider_token_a,
         secrets.debtor_service_provider.service_provider_id[:3],
     )
     assert res.status_code == 400
-    assert res.json()["errors"][0]["code"] == "01021003E"
-    assert res.json()["errors"][0]["description"] == "Invalid RTP Service Provider ID format."
+    assert res.json()["errors"][0]["code"] == ActivationErrorCode.INVALID_SERVICE_PROVIDER_ID_FORMAT.code
+    assert res.json()["errors"][0]["description"] == ActivationErrorCode.INVALID_SERVICE_PROVIDER_ID_FORMAT.description
 
 
 @allure.epic("Debtor Activation")

--- a/utils/activation_error_codes.py
+++ b/utils/activation_error_codes.py
@@ -1,0 +1,17 @@
+"""Named error codes returned by the Debtor Activation API in ``errors[].code`` / ``errors[].description``.
+
+Import ``ActivationErrorCode`` wherever a test needs to assert on one of these
+error responses instead of hardcoding the raw code/description strings.
+"""
+
+from enum import Enum
+
+
+class ActivationErrorCode(Enum):
+    INVALID_FISCAL_CODE_FORMAT = ("01021002E", "Invalid fiscal code format.")
+    INVALID_SERVICE_PROVIDER_ID_FORMAT = ("01021003E", "Invalid RTP Service Provider ID format.")
+    USER_ALREADY_ACTIVE = ("01031006E", "User is already active")
+
+    def __init__(self, code: str, description: str):
+        self.code = code
+        self.description = description


### PR DESCRIPTION
### Description

This PR aligns the QA functional test suite for the `/activations` endpoint with the error-response fixes introduced upstream (renamed `PAYER_ALREADY_ACTIVE` error, dedicated `INVALID_FISCAL_CODE_FORMAT` / `INVALID_SERVICE_PROVIDER_ID_FORMAT` error codes, and the new `ErrorsDto` body on the "payer already active on another Service Provider" `409` response). One existing test asserted the old, generic Spring-generated validation error and would have failed against the fixed API; new tests were added to cover previously untested unhappy paths directly tied to the fix.

### List of changes

- Updated `test_cannot_activate_debtor_lower_fiscal_code` (`functional-tests/tests/activation/test_debtor_activation_create.py`) to expect the dedicated `01021002E` / "Invalid fiscal code format." error instead of the old generic `Pattern.activationReqDtoMono.payer.fiscalCode` code.
- Added `test_cannot_activate_debtor_lower_rtp_sp_id`: malformed `rtpSpId` (invalid BIC casing) now returns `01021003E` / "Invalid RTP Service Provider ID format."
- Added `test_cannot_activate_debtor_short_fiscal_code` and `test_cannot_activate_debtor_short_rtp_sp_id`: undersized `fiscalCode`/`rtpSpId` (triggering `@Size` rather than `@Pattern`) map to the same dedicated error codes as the pattern-violation cases, confirming the fix applies regardless of which bean-validation constraint fires.
- Strengthened `test_activate_debtor_already_active_on_another_service_provider_triggers_takeover` to assert the new `ErrorsDto` body (`01031006E` / "User is already active") on the `409` response, in addition to the existing `Location` header check, matching the same-SP conflict body intentionally reused to avoid leaking which SP a payer is active on.

### Motivation and context

The upstream `/activations` API changed its error responses to match the API documentation: malformed `fiscalCode`/`rtpSpId` now return dedicated error codes instead of generic validation messages, and the "already active on another SP" conflict now returns a body instead of an empty one. The existing QA suite asserted the old behavior in one case and had no coverage for the other two, so it needed to be updated to stay green and to actually verify the fix.

### Aggregation level

- [x] Test case
- [ ] Test suite

### Test type

- [x] Functional test
- [ ] Bdd test
- [ ] Performance
- [ ] End to end
- [ ] Performance

### Type of changes

- [x] Add new test case/suite
- [x] Modify existing test case/suite

### Test Results

- [x] Success
- [ ] Failure
- [ ] Poor performance
- [ ] Good performance

### Did you update secrets accordingly?

- [ ] Yes
  - [ ] `.secrets_template.yaml`
  - [ ] Pipelines' secure file
  - [ ] Confluence
- [x] Not needed
- [ ] No (_please provide further information_)

### Did you update dependencies accordingly?

- [ ] Yes (which requirements.txt did you update?)
- [x] Not needed


### Other information