### PR TITLE
feat: [SRTP-2056] add test for RTP delivery status with ERROR_SEND_RTP

### DIFF
--- a/functional-tests/tests/get_rtp/test_RTP_get_delivery_status.py
+++ b/functional-tests/tests/get_rtp/test_RTP_get_delivery_status.py
@@ -11,6 +11,7 @@ from config.configuration import secrets
 from utils.dataset_gpd_message import generate_gpd_message_payload
 from utils.fiscal_code_utils import fake_fc
 from utils.generators_utils import generate_notice_number, generate_random_organization_id
+from utils.rtp_send_helpers import get_rtp_by_notice_number
 
 _SEND_PROCESSING_WAIT_S = 5
 
@@ -118,6 +119,85 @@ def test_get_delivery_status_notice_number_not_found(
         access_token=debtor_service_provider_token_a,
         notice_number=generate_notice_number(),
         payee_id=generate_random_organization_id(),
+    )
+
+    assert delivery_response.status_code == 200, (
+        f"Expected HTTP 200, got {delivery_response.status_code}: {delivery_response.text}"
+    )
+
+    body = delivery_response.json()
+    assert set(body.keys()) <= {"status", "processingDate"}, (
+        f"Unexpected fields in response: {set(body.keys()) - {'status', 'processingDate'}}"
+    )
+
+    assert body.get("status") == _STATUS_NOT_DELIVERED, (
+        f"Expected status='{_STATUS_NOT_DELIVERED}', got status='{body.get('status')}'"
+    )
+    assert body.get("processingDate") is None, (
+        f"Expected 'processingDate' to be null or absent, got '{body.get('processingDate')}'"
+    )
+
+
+@allure.epic("RTP Get")
+@allure.feature("RTP Delivery Status")
+@allure.story("Payee checks whether an RTP was delivered")
+@allure.title("RTP with ERROR_SEND_RTP event → PD_RTP_NOT_DELIVERED")
+@allure.tag("functional", "unhappy_path", "get", "rtp_get")
+@pytest.mark.get
+@pytest.mark.unhappy_path
+def test_get_delivery_status_error_send_rtp(
+    debtor_service_provider_token_a: str,
+    rtp_consumer_access_token: str,
+    rtp_reader_access_token: str,
+) -> None:
+    """
+    Given a debtor is activated with the mock fiscal code that makes the debtor
+    service provider mock reply with a server error, when a GPD message (CREATE)
+    is sent via POST /gpd/message, then the rtp-sender fails to deliver the RTP
+    and records an ERROR_SEND_RTP event (RTP status becomes ERROR_SEND). When the
+    payee then queries the delivery-status endpoint with the matching noticeNumber
+    and payeeId, the response must be HTTP 200 with status=PD_RTP_NOT_DELIVERED
+    and processingDate absent or null.
+    """
+    fiscal_code: str = secrets.mock_server_error_fiscal_code
+
+    activation_response = activate(
+        debtor_service_provider_token_a,
+        fiscal_code,
+        secrets.debtor_service_provider.service_provider_id,
+    )
+    assert activation_response.status_code in (201, 409), (
+        f"Debtor activation failed: {activation_response.status_code} {activation_response.text}"
+    )
+
+    message_payload = generate_gpd_message_payload(fiscal_code, "CREATE")
+
+    send_response = send_gpd_message(
+        access_token=rtp_consumer_access_token,
+        message_payload=message_payload,
+    )
+    assert send_response.status_code == 500, (
+        f"Expected the mocked debtor service provider error to surface as HTTP 500, "
+        f"got {send_response.status_code}: {send_response.text}"
+    )
+
+    time.sleep(_SEND_PROCESSING_WAIT_S)
+
+    rtp = get_rtp_by_notice_number(rtp_reader_access_token, message_payload["nav"])
+    assert rtp.get("status") == "ERROR_SEND", (
+        f"Expected RTP status='ERROR_SEND', got status='{rtp.get('status')}'"
+    )
+
+    error_send_event = next(
+        (e for e in rtp.get("events", []) if e.get("triggerEvent") == "ERROR_SEND_RTP"),
+        None,
+    )
+    assert error_send_event is not None, "No ERROR_SEND_RTP event found in the RTP events"
+
+    delivery_response = get_rtp_delivery_status(
+        access_token=debtor_service_provider_token_a,
+        notice_number=message_payload["nav"],
+        payee_id=message_payload["ec_tax_code"],
     )
 
     assert delivery_response.status_code == 200, (

--- a/functional-tests/tests/get_rtp/test_RTP_get_delivery_status.py
+++ b/functional-tests/tests/get_rtp/test_RTP_get_delivery_status.py
@@ -176,8 +176,8 @@ def test_get_delivery_status_error_send_rtp(
         access_token=rtp_consumer_access_token,
         message_payload=message_payload,
     )
-    assert send_response.status_code == 500, (
-        f"Expected the mocked debtor service provider error to surface as HTTP 500, "
+    assert 500 <= send_response.status_code < 600, (
+        f"Expected the mocked debtor service provider error to surface as an HTTP 5xx, "
         f"got {send_response.status_code}: {send_response.text}"
     )
 


### PR DESCRIPTION
### Description

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

This PR adds functional test coverage for the `ERROR_SEND_RTP` event, which was previously untested end-to-end. Currently, the platform can mark an RTP as `ERROR_SEND` when the debtor service provider fails to accept a payment request, but no automated test verified this behavior or its downstream effect on the payee-facing delivery-status endpoint (`GET /rtps/delivery-status`).

The repo already provides a mock fiscal code (`MOCK_SERVER_ERROR_FISCAL_CODE`) that causes the debtor service provider mock to reply with a server error, but it was only used to check the raw mock endpoint reachability (`test_receive_server_error_from_mock`), not the full RTP platform flow (activation → GPD message → rtp-sender → RTP status/events).

This PR adds a new functional test that exercises the complete flow and asserts the resulting RTP status, the `ERROR_SEND_RTP` event, and the correct `PD_RTP_NOT_DELIVERED` outcome on the delivery-status endpoint.

### List of changes

<!--- Describe your changes in detail -->

- Added `test_get_delivery_status_error_send_rtp` in `functional-tests/tests/get_rtp/test_RTP_get_delivery_status.py`:
  - Activates a debtor using `secrets.mock_server_error_fiscal_code`.
  - Sends a GPD `CREATE` message and asserts the send call fails with HTTP 500 (mocked debtor SP error surfacing synchronously).
  - Retrieves the RTP by notice number and asserts its status is `ERROR_SEND` and that an `ERROR_SEND_RTP` event is present.
  - Calls `GET /rtps/delivery-status` and asserts the response is `status=PD_RTP_NOT_DELIVERED` with a null/absent `processingDate`.
- Reused the existing `get_rtp_by_notice_number` helper from `utils/rtp_send_helpers.py` (added import).

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

The delivery-status endpoint documents `PD_RTP_NOT_DELIVERED` as returned when "the RTP was not successfully delivered," which includes RTPs carrying an `ERROR_SEND_RTP` event. This scenario was not covered by any existing test — the only test using the server-error mock fiscal code tested the mock in isolation, without validating the RTP's resulting status/events or the delivery-status endpoint's behavior in this case. This PR closes that gap.

### Aggregation level

<!--- Did you write a single reusable test case, or a full test suite?  -->

- [x] Test case
- [ ] Test suite

### Test type

- [x] Functional test
- [ ] Bdd test
- [ ] Performance
- [ ] End to end
- [ ] Performance

### Type of changes

- [x] Add new test case/suite
- [ ] Modify existing test case/suite

### Test Results

- [x] Success
- [ ] Failure
- [ ] Poor performance
- [ ] Good performance

Verified locally against the live QA environment: all 4 tests in `test_RTP_get_delivery_status.py` (including the new one) pass.

### Did you update secrets accordingly?

- [ ] Yes
  - [ ] `.secrets_template.yaml`
  - [ ] Pipelines' secure file
  - [ ] Confluence
- [x] Not needed
- [ ] No (_please provide further information_)

No new secrets were introduced; the test reuses the existing `MOCK_SERVER_ERROR_FISCAL_CODE` secret already available in configuration.

### Did you update dependencies accordingly?

- [ ] Yes (which requirements.txt did you update?)
<!--- Describe which requirements.txt did you update -->
- [x] Not needed

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

None.
