### PR TITLE
feat: [SRTP-2069] add-body-to-404-not-found-for-get-activations-activationid

### DIFF
--- a/functional-tests/tests/activation/test_debtor_activation_get.py
+++ b/functional-tests/tests/activation/test_debtor_activation_get.py
@@ -147,10 +147,8 @@ def test_get_activation_by_id_not_found(debtor_service_provider_token_a):
     assert isinstance(error_body["errors"], list)
     assert len(error_body["errors"]) > 0
     for err in error_body["errors"]:
-        assert "code" in err
-        assert "description" in err
-        assert isinstance(err["code"], str)
-        assert isinstance(err["description"], str)
+        assert err["code"] == "01041000E"
+        assert err["description"] == "Activation not found."
 
 
 @allure.epic("Debtor Activation")

--- a/functional-tests/tests/activation/test_debtor_activation_get.py
+++ b/functional-tests/tests/activation/test_debtor_activation_get.py
@@ -141,6 +141,16 @@ def test_get_activation_by_id_not_found(debtor_service_provider_token_a):
     random_id = str(uuid.uuid4())
     res = get_activation_by_id(debtor_service_provider_token_a, random_id)
     assert res.status_code == 404
+    
+    error_body = res.json()
+    assert "errors" in error_body
+    assert isinstance(error_body["errors"], list)
+    assert len(error_body["errors"]) > 0
+    for err in error_body["errors"]:
+        assert "code" in err
+        assert "description" in err
+        assert isinstance(err["code"], str)
+        assert isinstance(err["description"], str)
 
 
 @allure.epic("Debtor Activation")


### PR DESCRIPTION
### Description

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

Updated the functional test `test_get_activation_by_id_not_found` to assert that the `GET /activations/{activationId}` endpoint returns a structured JSON error body when an activation is not found.

### List of changes

<!--- Describe your changes in detail -->
- Added response body validation to the 404 test case.
### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

This change aligns the QA integration test suite with the updated API behavior. A `404 Not Found` response on GET activation must return a structured error body instead of an empty payload.

### Aggregation level

<!--- Did you write a single reusable test case, or a full test suite?  -->

- [ ] Test case
- [x] Test suite

### Test type

- [x] Functional test
- [ ] Bdd test
- [ ] Performance
- [ ] End to end
- [ ] Performance

### Type of changes

- [ ] Add new test case/suite
- [x] Modify existing test case/suite

### Test Results

- [x] Success
- [ ] Failure
- [ ] Poor performance
- [ ] Good performance

### Did you update secrets accordingly?

- [ ] Yes
  - [ ] `.secrets_template.yaml`
  - [ ] Pipelines' secure file
  - [ ] Confluence
- [x] Not needed
- [ ] No (_please provide further information_)

### Did you update dependencies accordingly?

- [ ] Yes (which requirements.txt did you update?)
<!--- Describe which requirements.txt did you update -->
- [x] Not needed


### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
