### PR TITLE
feat: [SRTP-2091] add body to error get activations payer

### DIFF
--- a/functional-tests/tests/activation/test_debtor_activation_create.py
+++ b/functional-tests/tests/activation/test_debtor_activation_create.py
@@ -230,3 +230,10 @@ def test_cannot_get_activation_lower_fiscal_code(debtor_service_provider_token_a
 
     res = get_activation_by_payer_id(debtor_service_provider_token_a, random_fiscal_code.lower())
     assert res.status_code == 400
+    error_body = res.json()
+    assert "errors" in error_body
+    assert isinstance(error_body["errors"], list)
+    assert len(error_body["errors"]) > 0
+    for err in error_body["errors"]:
+        assert err["code"] == "01021013E"
+        assert err["description"] == "Invalid Payer ID format."

--- a/functional-tests/tests/activation/test_debtor_activation_get.py
+++ b/functional-tests/tests/activation/test_debtor_activation_get.py
@@ -4,7 +4,7 @@ from datetime import datetime
 import allure
 import pytest
 
-from api.debtor_activation_api import get_activation_by_id
+from api.debtor_activation_api import get_activation_by_id, get_activation_by_payer_id
 from config.configuration import secrets
 
 
@@ -164,3 +164,48 @@ def test_get_activation_by_id_invalid_uuid(debtor_service_provider_token_a):
     invalid_id = "not-a-valid-uuid"
     res = get_activation_by_id(debtor_service_provider_token_a, invalid_id)
     assert res.status_code == 400
+
+
+@allure.epic("Debtor Activation")
+@allure.feature("Activation")
+@allure.story("Get Debtor activation by Payer ID")
+@allure.title("Retrieving non-existent activation by payer id returns 404")
+@allure.tag("functional", "unhappy_path", "activation", "debtor_activation")
+@pytest.mark.auth
+@pytest.mark.activation
+@pytest.mark.unhappy_path
+def test_get_activation_by_payer_id_not_found(debtor_service_provider_token_a, random_fiscal_code):
+
+    res = get_activation_by_payer_id(debtor_service_provider_token_a, random_fiscal_code)
+    assert res.status_code == 404
+    
+    error_body = res.json()
+    assert "errors" in error_body
+    assert isinstance(error_body["errors"], list)
+    assert len(error_body["errors"]) > 0
+    for err in error_body["errors"]:
+        assert err["code"] == "01041000E"
+        assert err["description"] == "Activation not found."
+
+
+@allure.epic("Debtor Activation")
+@allure.feature("Activation")
+@allure.story("Get Debtor activation by Payer ID")
+@allure.title("Retrieving activation with malformed payer id returns 400")
+@allure.tag("functional", "unhappy_path", "activation", "debtor_activation")
+@pytest.mark.auth
+@pytest.mark.activation
+@pytest.mark.unhappy_path
+def test_get_activation_by_payer_id_malformed(debtor_service_provider_token_a):
+
+    invalid_payer_id = "INVALID_PAYER_ID"
+    res = get_activation_by_payer_id(debtor_service_provider_token_a, invalid_payer_id)
+    assert res.status_code == 400
+    
+    error_body = res.json()
+    assert "errors" in error_body
+    assert isinstance(error_body["errors"], list)
+    assert len(error_body["errors"]) > 0
+    for err in error_body["errors"]:
+        assert err["code"] == "01021013E"
+        assert err["description"] == "Invalid Payer ID format."


### PR DESCRIPTION
### Description

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Adds error body assertions (code and description) for `GET /rtp/activation/activations/payer` negative test cases.
### List of changes

<!--- Describe your changes in detail -->
- Added `test_get_activation_by_payer_id_not_found` (404, `01041000E`) in `test_debtor_activation_get.py`.
- Added `test_get_activation_by_payer_id_malformed` (400, `01021013E`) in `test_debtor_activation_get.py`.
- Added error payload assertions to `test_cannot_get_activation_lower_fiscal_code` in `test_debtor_activation_create.py`.
### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Ensures functional tests validate not only HTTP status codes (400/404), but also exact error codes and descriptions.

### Aggregation level

<!--- Did you write a single reusable test case, or a full test suite?  -->

- [ ] Test case
- [x] Test suite

### Test type

- [x] Functional test
- [ ] Bdd test
- [ ] Performance
- [ ] End to end
- [ ] Performance

### Type of changes

- [x] Add new test case/suite
- [x] Modify existing test case/suite

### Test Results

- [x] Success
- [ ] Failure
- [ ] Poor performance
- [ ] Good performance

### Did you update secrets accordingly?

- [ ] Yes
  - [ ] `.secrets_template.yaml`
  - [ ] Pipelines' secure file
  - [ ] Confluence
- [x] Not needed
- [ ] No (_please provide further information_)

### Did you update dependencies accordingly?

- [ ] Yes (which requirements.txt did you update?)
<!--- Describe which requirements.txt did you update -->
- [x] Not needed


### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
