### PR TITLE
fix: [SRTP-2101] fix RTP callback v1 tests

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -55,16 +55,16 @@ service_providers_registry: 'service_providers/service-providers'
 service_providers_registry_api_version: 'v1'
 
 # ============================
-# CALLBACK URL
+# CALLBACK URL - v1
 # ============================
-callback_url: "https://api-rtp-cb.uat.cstar.pagopa.it/rtp/cb/send"
+callback_url: "https://api-rtp-cb.uat.cstar.pagopa.it/rtp/cb/v1/send"
 callback_api_version: 'v1'
 
 # ============================
-# RFC (REQUEST FOR CANCELLATION) CALLBACK URL
-rfc_callback_url: "https://api-rtp-cb.uat.cstar.pagopa.it/rtp/cb/cancel"
-rfc_callback_api_version: 'v1'
+# RFC (REQUEST FOR CANCELLATION) CALLBACK URL - v1
 # ============================
+rfc_callback_url: "https://api-rtp-cb.uat.cstar.pagopa.it/rtp/cb/v1/cancel"
+rfc_callback_api_version: 'v1'
 
 # ============================
 # MOCK SERVICES & API SPECIFICATIONS

--- a/functional-tests/tests/callbacks/test_RTP_callback_DS_04.py
+++ b/functional-tests/tests/callbacks/test_RTP_callback_DS_04.py
@@ -68,7 +68,7 @@ def test_fail_send_rtp_callback_wrong_certificate_serial_DS_04b_compliant(
     debtor_sp_mock_cert_key,
 ):
 
-    callback_data = generate_callback_data_DS_04b_compliant(bic="MOCKSP01")
+    callback_data = generate_callback_data_DS_04b_compliant(bic="FAKESP01")
 
     cert, key = debtor_sp_mock_cert_key
 

--- a/functional-tests/tests/callbacks/test_RTP_callback_DS_08.py
+++ b/functional-tests/tests/callbacks/test_RTP_callback_DS_08.py
@@ -273,7 +273,7 @@ def test_receive_rtp_callback_DS_08P_compliant_ACWC(
 def test_fail_send_rtp_callback_wrong_certificate_serial_DS_08N_compliant(
     debtor_sp_mock_cert_key,
 ):
-    callback_data = generate_callback_data_DS_08N_compliant(bic="MOCKSP01")
+    callback_data = generate_callback_data_DS_08N_compliant(bic="FAKESP01")
 
     cert, key = debtor_sp_mock_cert_key
 

--- a/functional-tests/tests/callbacks/test_RTP_callback_DS_12N.py
+++ b/functional-tests/tests/callbacks/test_RTP_callback_DS_12N.py
@@ -99,7 +99,7 @@ def test_fail_send_rfc_callback_wrong_certificate_serial_DS_12N_RJCR_compliant(
     1. Activate payer
     2. Send an RTP via GPD message (CREATE VALID)
     3. Cancel the RTP via GPD message (DELETE) → RTP to RFC_SENT
-    4. Send DS12N callback with assignee_bic='MOCKSP01' (doesn't match certificate identity MOCKSP04)
+    4. Send DS12N callback with assignee_bic='FAKESP01' (doesn't match certificate identity MOCKSP04)
     5. Verify callback is rejected with 403 (certificate mismatch)
     """
 
@@ -122,7 +122,7 @@ def test_fail_send_rfc_callback_wrong_certificate_serial_DS_12N_RJCR_compliant(
     callback_data = generate_callback_data_DS_12N_RJCR_compliant(
         resource_id=resource_id,
         original_msg_id=original_msg_id,
-        assignee_bic="MOCKSP01",
+        assignee_bic="FAKESP01",
     )
 
     cert, key = debtor_sp_mock_cert_key
@@ -360,7 +360,7 @@ def test_fail_send_rfc_callback_wrong_certificate_serial_DS_12N_RJCR_compliant_T
     1. Activate payer
     2. Send an RTP via GPD message (CREATE VALID)
     3. Cancel the RTP via REST cancel endpoint with cancel_reason → RTP to RFC_SENT
-    4. Send DS12N callback with assignee_bic='MOCKSP01' (doesn't match certificate identity MOCKSP04)
+    4. Send DS12N callback with assignee_bic='FAKESP01' (doesn't match certificate identity MOCKSP04)
     5. Verify callback is rejected with 403 (certificate mismatch)
     """
 
@@ -382,7 +382,7 @@ def test_fail_send_rfc_callback_wrong_certificate_serial_DS_12N_RJCR_compliant_T
     callback_data = generate_callback_data_DS_12N_RJCR_compliant(
         resource_id=resource_id,
         original_msg_id=original_msg_id,
-        assignee_bic="MOCKSP01",
+        assignee_bic="FAKESP01",
     )
 
     cert, key = debtor_sp_mock_cert_key

--- a/functional-tests/tests/callbacks/test_RTP_callback_DS_12P.py
+++ b/functional-tests/tests/callbacks/test_RTP_callback_DS_12P.py
@@ -99,7 +99,7 @@ def test_fail_send_rfc_callback_wrong_certificate_serial_DS_12P_CNCL_compliant(
     1. Activate payer
     2. Send an RTP via GPD message (CREATE VALID)
     3. Cancel the RTP via GPD message (DELETE) → RTP to RFC_SENT
-    4. Send DS12P callback with assignee_bic='MOCKSP01' (doesn't match certificate identity MOCKSP04)
+    4. Send DS12P callback with assignee_bic='FAKESP01' (doesn't match certificate identity MOCKSP04)
     5. Verify callback is rejected with 403 (certificate mismatch)
     """
 
@@ -122,7 +122,7 @@ def test_fail_send_rfc_callback_wrong_certificate_serial_DS_12P_CNCL_compliant(
     callback_data = generate_callback_data_DS_12P_CNCL_compliant(
         resource_id=resource_id,
         original_msg_id=original_msg_id,
-        assignee_bic="MOCKSP01",
+        assignee_bic="FAKESP01",
     )
 
     cert, key = debtor_sp_mock_cert_key
@@ -358,7 +358,7 @@ def test_fail_send_rfc_callback_wrong_certificate_serial_DS_12P_CNCL_compliant_T
     1. Activate payer
     2. Send an RTP via GPD message (CREATE VALID)
     3. Cancel the RTP via REST cancel endpoint with cancel_reason → RTP to RFC_SENT
-    4. Send DS12P callback with assignee_bic='MOCKSP01' (doesn't match certificate identity MOCKSP04)
+    4. Send DS12P callback with assignee_bic='FAKESP01' (doesn't match certificate identity MOCKSP04)
     5. Verify callback is rejected with 403 (certificate mismatch)
     """
 
@@ -380,7 +380,7 @@ def test_fail_send_rfc_callback_wrong_certificate_serial_DS_12P_CNCL_compliant_T
     callback_data = generate_callback_data_DS_12P_CNCL_compliant(
         resource_id=resource_id,
         original_msg_id=original_msg_id,
-        assignee_bic="MOCKSP01",
+        assignee_bic="FAKESP01",
     )
 
     cert, key = debtor_sp_mock_cert_key

--- a/functional-tests/tests/callbacks/test_RTP_callback_with_version_header.py
+++ b/functional-tests/tests/callbacks/test_RTP_callback_with_version_header.py
@@ -32,7 +32,6 @@ from utils.dataset_callback_data_DS_12N_RJCR_compliant import generate_callback_
 from utils.dataset_callback_data_DS_12P_CNCL_compliant import generate_callback_data_DS_12P_CNCL_compliant
 from utils.dataset_gpd_message import generate_gpd_delete_message_payload, generate_gpd_message_payload
 
-
 # ---------------------------------------------------------------------------
 # RTP callback endpoint (DS_04, DS_05, DS_08)
 # ---------------------------------------------------------------------------
@@ -171,9 +170,7 @@ def test_rtp_callback_DS_05_ACTC_with_version_header(
     get_response = get_rtp(access_token=rtp_reader_access_token, rtp_id=resource_id)
     assert get_response.status_code == 200
     body = get_response.json()
-    assert body["status"] == "SENT", (
-        f"RTP status must remain SENT when Version header is present, got {body['status']}"
-    )
+    assert body["status"] == "SENT", f"RTP status must remain SENT when Version header is present, got {body['status']}"
 
 
 @allure.epic("RTP Callback")
@@ -226,9 +223,7 @@ def test_rtp_callback_DS_08P_ACCP_with_version_header(
         key_path=key,
         include_version_header=False,
     )
-    assert ds05_response.status_code == 200, (
-        f"DS_05 setup step failed: expected 200 got {ds05_response.status_code}"
-    )
+    assert ds05_response.status_code == 200, f"DS_05 setup step failed: expected 200 got {ds05_response.status_code}"
 
     # Now send DS_08P ACCP with Version header
     callback_data = build_callback_with_original_msg_id(
@@ -321,9 +316,7 @@ def test_rtp_callback_DS_08N_with_version_header(
     get_response = get_rtp(access_token=rtp_reader_access_token, rtp_id=resource_id)
     assert get_response.status_code == 200
     body = get_response.json()
-    assert body["status"] == "SENT", (
-        f"RTP status must remain SENT when Version header is present, got {body['status']}"
-    )
+    assert body["status"] == "SENT", f"RTP status must remain SENT when Version header is present, got {body['status']}"
 
 
 # ---------------------------------------------------------------------------
@@ -370,9 +363,7 @@ def test_rfc_callback_DS_12P_CNCL_with_version_header(
 
     delete_payload = generate_gpd_delete_message_payload(msg_id=message_payload["id"], iuv=message_payload["iuv"])
     cancel_response = send_gpd_message(access_token=rtp_consumer_access_token, message_payload=delete_payload)
-    assert cancel_response.status_code == 200, (
-        f"Error cancelling RTP via DELETE, got {cancel_response.status_code}"
-    )
+    assert cancel_response.status_code == 200, f"Error cancelling RTP via DELETE, got {cancel_response.status_code}"
 
     callback_data = generate_callback_data_DS_12P_CNCL_compliant(
         resource_id=resource_id,
@@ -442,9 +433,7 @@ def test_rfc_callback_DS_12N_RJCR_with_version_header(
 
     delete_payload = generate_gpd_delete_message_payload(msg_id=message_payload["id"], iuv=message_payload["iuv"])
     cancel_response = send_gpd_message(access_token=rtp_consumer_access_token, message_payload=delete_payload)
-    assert cancel_response.status_code == 200, (
-        f"Error cancelling RTP via DELETE, got {cancel_response.status_code}"
-    )
+    assert cancel_response.status_code == 200, f"Error cancelling RTP via DELETE, got {cancel_response.status_code}"
 
     callback_data = generate_callback_data_DS_12N_RJCR_compliant(
         resource_id=resource_id,


### PR DESCRIPTION
### Description

This PR fixes the RTP callback (v1) functional tests so they keep working against the callback service, whose v1 endpoints now require the `/v1/` version segment in the URL path. It also corrects a couple of "wrong certificate serial" test cases that were using a BIC that actually matched the mock certificate identity, instead of a mismatching one..

### List of changes

- `config.yaml`: updated `callback_url` and `rfc_callback_url` to include the `/v1/` path segment (`.../rtp/cb/v1/send`, `.../rtp/cb/v1/cancel`).
- `functional-tests/tests/callbacks/test_RTP_callback_DS_04.py`, `test_RTP_callback_DS_08.py`, `test_RTP_callback_DS_12N.py`, `test_RTP_callback_DS_12P.py`: fixed the wrong-certificate-serial tests to use `bic="FAKESP01"` instead of `bic="MOCKSP01"`, so the payload BIC genuinely doesn't match the certificate identity.
- `functional-tests/tests/callbacks/test_RTP_callback_with_version_header.py`: cosmetic reformatting (ruff-format), no functional change.

### Motivation and context

The callback service now requires the API version in the URL path even for v1 endpoints; without this change, v1 callback tests would call an outdated (non-versioned) URL. The BIC fix was needed because the previous value coincidentally matched the mock certificate identity, so the "wrong certificate" negative tests weren't actually exercising a mismatch.

### Aggregation level

- [ ] Test case
- [x] Test suite

### Test type

- [x] Functional test
- [ ] Bdd test
- [ ] Performance
- [ ] End to end
- [ ] Performance

### Type of changes

- [ ] Add new test case/suite
- [x] Modify existing test case/suite

### Test Results

- [x] Success
- [ ] Failure
- [ ] Poor performance
- [ ] Good performance

Ran locally: `pytest functional-tests/tests/callbacks -q` → 45 passed.

### Did you update secrets accordingly?

- [ ] Yes
  - [ ] `.secrets_template.yaml`
  - [ ] Pipelines' secure file
  - [ ] Confluence
- [x] Not needed
- [ ] No (_please provide further information_)

### Did you update dependencies accordingly?

- [ ] Yes (which requirements.txt did you update?)
- [x] Not needed

### Other information