### PR TITLE
fix: [SRTP-2111] gh-pages report generation

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -148,7 +148,7 @@ jobs:
           ref: gh-pages
           path: gh-pages
       - name: Build test report
-        uses: simple-elf/allure-report-action@53ebb757a2097edc77c53ecef4d454fc2f2f774c
+        uses: simple-elf/allure-report-action@385367cde61ac68c2568a117f7579f7f148dc459 #v1.15 (fixes missing findutils/xargs bug from v1.13)
         if: always()
         continue-on-error: true
         with:
@@ -213,7 +213,7 @@ jobs:
           ref: gh-pages
           path: gh-pages
       - name: Build test report
-        uses: simple-elf/allure-report-action@53ebb757a2097edc77c53ecef4d454fc2f2f774c
+        uses: simple-elf/allure-report-action@385367cde61ac68c2568a117f7579f7f148dc459 #v1.15 (fixes missing findutils/xargs bug from v1.13)
         if: always()
         continue-on-error: true
         with:
@@ -281,7 +281,7 @@ jobs:
           ref: gh-pages
           path: gh-pages
       - name: Build test report
-        uses: simple-elf/allure-report-action@53ebb757a2097edc77c53ecef4d454fc2f2f774c
+        uses: simple-elf/allure-report-action@385367cde61ac68c2568a117f7579f7f148dc459 #v1.15 (fixes missing findutils/xargs bug from v1.13)
         if: always()
         continue-on-error: true
         with:
@@ -346,7 +346,7 @@ jobs:
           ref: gh-pages
           path: gh-pages
       - name: Build test report
-        uses: simple-elf/allure-report-action@53ebb757a2097edc77c53ecef4d454fc2f2f774c
+        uses: simple-elf/allure-report-action@385367cde61ac68c2568a117f7579f7f148dc459 #v1.15 (fixes missing findutils/xargs bug from v1.13)
         if: always()
         continue-on-error: true
         with:
@@ -417,7 +417,7 @@ jobs:
           ref: gh-pages
           path: gh-pages
       - name: Build test report
-        uses: simple-elf/allure-report-action@53ebb757a2097edc77c53ecef4d454fc2f2f774c
+        uses: simple-elf/allure-report-action@385367cde61ac68c2568a117f7579f7f148dc459 #v1.15 (fixes missing findutils/xargs bug from v1.13)
         if: always()
         continue-on-error: true
         with:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -148,7 +148,7 @@ jobs:
           ref: gh-pages
           path: gh-pages
       - name: Build test report
-        uses: simple-elf/allure-report-action@385367cde61ac68c2568a117f7579f7f148dc459 #v1.15 (fixes missing findutils/xargs bug from v1.13)
+        uses: simple-elf/allure-report-action@385367cde61ac68c2568a117f7579f7f148dc459
         if: always()
         continue-on-error: true
         with:
@@ -213,7 +213,7 @@ jobs:
           ref: gh-pages
           path: gh-pages
       - name: Build test report
-        uses: simple-elf/allure-report-action@385367cde61ac68c2568a117f7579f7f148dc459 #v1.15 (fixes missing findutils/xargs bug from v1.13)
+        uses: simple-elf/allure-report-action@385367cde61ac68c2568a117f7579f7f148dc459
         if: always()
         continue-on-error: true
         with:
@@ -281,7 +281,7 @@ jobs:
           ref: gh-pages
           path: gh-pages
       - name: Build test report
-        uses: simple-elf/allure-report-action@385367cde61ac68c2568a117f7579f7f148dc459 #v1.15 (fixes missing findutils/xargs bug from v1.13)
+        uses: simple-elf/allure-report-action@385367cde61ac68c2568a117f7579f7f148dc459
         if: always()
         continue-on-error: true
         with:
@@ -346,7 +346,7 @@ jobs:
           ref: gh-pages
           path: gh-pages
       - name: Build test report
-        uses: simple-elf/allure-report-action@385367cde61ac68c2568a117f7579f7f148dc459 #v1.15 (fixes missing findutils/xargs bug from v1.13)
+        uses: simple-elf/allure-report-action@385367cde61ac68c2568a117f7579f7f148dc459
         if: always()
         continue-on-error: true
         with:
@@ -417,7 +417,7 @@ jobs:
           ref: gh-pages
           path: gh-pages
       - name: Build test report
-        uses: simple-elf/allure-report-action@385367cde61ac68c2568a117f7579f7f148dc459 #v1.15 (fixes missing findutils/xargs bug from v1.13)
+        uses: simple-elf/allure-report-action@385367cde61ac68c2568a117f7579f7f148dc459
         if: always()
         continue-on-error: true
         with:


### PR DESCRIPTION
### Description

The Slack notification and the GitHub Actions run summary were pointing to Allure report links (e.g. `https://pagopa.github.io/rtp-platform-qa/1086/index.html`) that returned a 404, even though the pipeline reported success. Meanwhile, the `gh-pages` branch was actually stuck publishing report `1069` and never advancing, regardless of how many workflow runs completed afterwards.

### List of changes

- Bumped the pinned commit of the `simple-elf/allure-report-action` GitHub Action used in `run_tests.yml` (5 occurrences, one per test stage: Functional, BDD, UX, Contract, Aggregate_Results) from commit `53ebb757a...` (tag `v1.13`) to commit `385367cde...` (tag `v1.15`).

### Motivation and context

Root-caused by inspecting the `Build test report` job logs: the pinned action's Docker image (based on `amazoncorretto:8`) only installs `tar`, `wget` and `gzip` via `yum`, but does **not** install `findutils`, so the `xargs` binary is missing inside the container. The Allure CLI launcher script requires `xargs` to run at all — when it's missing it fails fast with `xargs is not available` and exits without generating any report.

Because of this, the `allure generate` step silently produced nothing, and the subsequent `cp` of the generated report into a new numbered folder (e.g. `allure-history/1086`) failed (`cp: cannot stat './allure-report/.': No such file or directory`). However, the action still unconditionally regenerates the top-level `index.html` redirect (and thus the Slack notification link) using the current run number, regardless of whether the report was actually generated and copied. This produced a broken link every time, while `gh-pages` silently stayed frozen at the last run that had successfully generated a report (`1069`).

Upstream already fixed this exact issue in `simple-elf/allure-report-action` via commit `8ca41ab` ("add findutils to dockerfile, fixes #77"), included starting from tag `v1.14`. Updating our pin to `v1.15` picks up the fix (and also bumps the bundled Allure commandline to 2.44.0).

### Aggregation level

- [ ] Test case
- [ ] Test suite

### Test type

- [ ] Functional test
- [ ] Bdd test
- [ ] Performance
- [ ] End to end
- [ ] Performance

### Type of changes

- [ ] Add new test case/suite
- [ ] Modify existing test case/suite

### Test Results

- [ ] Success
- [ ] Failure
- [ ] Poor performance
- [ ] Good performance

### Did you update secrets accordingly?

- [x] Not needed

### Did you update dependencies accordingly?

- [x] Not needed

### Other information

This is a CI/infrastructure fix (GitHub Actions workflow only), not a test case change — none of the "Aggregation level", "Test type", "Type of changes" or "Test Results" checkboxes apply. Verification: will be confirmed on the next scheduled/manual run of `Run Tests`, checking that a new numbered report folder is created under `gh-pages` and that the Slack notification link resolves correctly.