### PR TITLE
feat: [SRTP-2110] add ownership tests for activation and takeover

### DIFF
--- a/functional-tests/tests/activation/test_debtor_activation_create.py
+++ b/functional-tests/tests/activation/test_debtor_activation_create.py
@@ -11,6 +11,7 @@ from utils.dataset_payer_id_invalid import INVALID_PAYER_IDS
 from utils.http_utils import extract_id_from_location
 from utils.regex_utils import uuidv4_pattern
 
+
 @allure.epic("Debtor Activation")
 @allure.feature("Activation")
 @allure.story("Debtor activation")
@@ -237,3 +238,68 @@ def test_cannot_get_activation_lower_fiscal_code(debtor_service_provider_token_a
     for err in error_body["errors"]:
         assert err["code"] == "01021013E"
         assert err["description"] == "Invalid Payer ID format."
+
+
+@allure.epic("Debtor Activation")
+@allure.feature("Activation")
+@allure.story("Debtor activation")
+@allure.title("A debtor is activated using a Service Provider ID the token subject owns but does not itself represent")
+@allure.tag("functional", "happy_path", "activation", "debtor_activation", "ownership")
+@pytest.mark.auth
+@pytest.mark.activation
+@pytest.mark.happy_path
+def test_activate_debtor_with_owned_but_distinct_service_provider_id(
+    debtor_service_provider_token_a, random_fiscal_code
+):
+    """MOCKSP04 owns MOCKSP01 as well as its own spId; activation must be allowed on either."""
+
+    owned_alt_sp_id = "MOCKSP01"
+    res = activate(debtor_service_provider_token_a, random_fiscal_code, "MOCKSP01")
+    assert res.status_code == 201, (
+        f"Error activating debtor with owned Service Provider ID, expected 201 but got {res.status_code} - {res.text}"
+    )
+
+    res = get_activation_by_payer_id(debtor_service_provider_token_a, random_fiscal_code)
+    assert res.status_code == 200
+    assert res.json()["payer"]["rtpSpId"] == owned_alt_sp_id
+
+
+@allure.epic("Debtor Activation")
+@allure.feature("Activation")
+@allure.story("Debtor activation")
+@allure.title("Activation is forbidden for a Service Provider ID not owned by the token subject")
+@allure.tag("functional", "unhappy_path", "activation", "debtor_activation", "ownership")
+@pytest.mark.auth
+@pytest.mark.activation
+@pytest.mark.unhappy_path
+def test_activate_debtor_forbidden_for_not_owned_service_provider_id(
+    debtor_service_provider_token_b, random_fiscal_code
+):
+    """FAKESP01 does not own MOCKSP01, a Service Provider ID owned by another tspId."""
+
+    res = activate(debtor_service_provider_token_b, random_fiscal_code, "MOCKSP01")
+    assert res.status_code == 403, f"Expected 403 for not-owned Service Provider ID, got {res.status_code}: {res.text}"
+    assert res.json()["errors"][0]["code"] == ActivationErrorCode.SERVICE_PROVIDER_ID_NOT_OWNED.code
+    assert res.json()["errors"][0]["description"] == ActivationErrorCode.SERVICE_PROVIDER_ID_NOT_OWNED.description
+
+
+@allure.epic("Debtor Activation")
+@allure.feature("Activation")
+@allure.story("Debtor activation")
+@allure.title("Activation is forbidden with the same error code for a Service Provider ID absent from the registry")
+@allure.tag("functional", "unhappy_path", "activation", "debtor_activation", "ownership")
+@pytest.mark.auth
+@pytest.mark.activation
+@pytest.mark.unhappy_path
+def test_activate_debtor_forbidden_for_nonexistent_service_provider_id(
+    debtor_service_provider_token_b, random_fiscal_code
+):
+    """The ownership check fails the same way whether the target spId belongs to someone else
+    or doesn't exist in the registry at all - NOEXIT00 is not a real Service Provider ID."""
+
+    res = activate(debtor_service_provider_token_b, random_fiscal_code, "NOEXIT00")
+    assert res.status_code == 403, (
+        f"Expected 403 for nonexistent Service Provider ID, got {res.status_code}: {res.text}"
+    )
+    assert res.json()["errors"][0]["code"] == ActivationErrorCode.SERVICE_PROVIDER_ID_NOT_OWNED.code
+    assert res.json()["errors"][0]["description"] == ActivationErrorCode.SERVICE_PROVIDER_ID_NOT_OWNED.description

--- a/functional-tests/tests/activation/test_debtor_activation_create.py
+++ b/functional-tests/tests/activation/test_debtor_activation_create.py
@@ -254,7 +254,7 @@ def test_activate_debtor_with_owned_but_distinct_service_provider_id(
     """MOCKSP04 owns MOCKSP01 as well as its own spId; activation must be allowed on either."""
 
     owned_alt_sp_id = "MOCKSP01"
-    res = activate(debtor_service_provider_token_a, random_fiscal_code, "MOCKSP01")
+    res = activate(debtor_service_provider_token_a, random_fiscal_code, owned_alt_sp_id)
     assert res.status_code == 201, (
         f"Error activating debtor with owned Service Provider ID, expected 201 but got {res.status_code} - {res.text}"
     )

--- a/functional-tests/tests/activation/test_debtor_activation_get.py
+++ b/functional-tests/tests/activation/test_debtor_activation_get.py
@@ -178,7 +178,7 @@ def test_get_activation_by_payer_id_not_found(debtor_service_provider_token_a, r
 
     res = get_activation_by_payer_id(debtor_service_provider_token_a, random_fiscal_code)
     assert res.status_code == 404
-    
+
     error_body = res.json()
     assert "errors" in error_body
     assert isinstance(error_body["errors"], list)
@@ -201,7 +201,7 @@ def test_get_activation_by_payer_id_malformed(debtor_service_provider_token_a):
     invalid_payer_id = "INVALID_PAYER_ID"
     res = get_activation_by_payer_id(debtor_service_provider_token_a, invalid_payer_id)
     assert res.status_code == 400
-    
+
     error_body = res.json()
     assert "errors" in error_body
     assert isinstance(error_body["errors"], list)

--- a/functional-tests/tests/activation/test_debtor_activation_get.py
+++ b/functional-tests/tests/activation/test_debtor_activation_get.py
@@ -4,7 +4,7 @@ from datetime import datetime
 import allure
 import pytest
 
-from api.debtor_activation_api import get_activation_by_id, get_activation_by_payer_id
+from api.debtor_activation_api import activate, get_activation_by_id, get_activation_by_payer_id
 from config.configuration import secrets
 
 
@@ -141,7 +141,7 @@ def test_get_activation_by_id_not_found(debtor_service_provider_token_a):
     random_id = str(uuid.uuid4())
     res = get_activation_by_id(debtor_service_provider_token_a, random_id)
     assert res.status_code == 404
-    
+
     error_body = res.json()
     assert "errors" in error_body
     assert isinstance(error_body["errors"], list)
@@ -209,3 +209,89 @@ def test_get_activation_by_payer_id_malformed(debtor_service_provider_token_a):
     for err in error_body["errors"]:
         assert err["code"] == "01021013E"
         assert err["description"] == "Invalid Payer ID format."
+
+
+@allure.epic("Debtor Activation")
+@allure.feature("Activation")
+@allure.story("Get Debtor activation by ID")
+@allure.title("A debtor activated with an owned but distinct Service Provider ID is retrieved by activation id")
+@allure.tag("functional", "happy_path", "activation", "debtor_activation", "ownership")
+@pytest.mark.auth
+@pytest.mark.activation
+@pytest.mark.happy_path
+def test_get_activation_by_id_owned_but_distinct_service_provider_id(
+    debtor_service_provider_token_a, random_fiscal_code
+):
+
+    owned_alt_sp_id = "MOCKSP01"
+    activation_response = activate(debtor_service_provider_token_a, random_fiscal_code, owned_alt_sp_id)
+    assert activation_response.status_code == 201, f"Error activating debtor: {activation_response.text}"
+    activation_id = activation_response.headers["Location"].split("/")[-1]
+
+    res = get_activation_by_id(debtor_service_provider_token_a, activation_id)
+    assert res.status_code == 200, f"Expected 200 but got {res.status_code}"
+    assert res.json()["payer"]["fiscalCode"] == random_fiscal_code
+    assert res.json()["payer"]["rtpSpId"] == owned_alt_sp_id
+
+
+@allure.epic("Debtor Activation")
+@allure.feature("Activation")
+@allure.story("Get Debtor activation by Payer ID")
+@allure.title("A debtor activated with an owned but distinct Service Provider ID is retrieved by payer id")
+@allure.tag("functional", "happy_path", "activation", "debtor_activation", "ownership")
+@pytest.mark.auth
+@pytest.mark.activation
+@pytest.mark.happy_path
+def test_get_activation_by_payer_id_owned_but_distinct_service_provider_id(
+    debtor_service_provider_token_a, random_fiscal_code
+):
+
+    owned_alt_sp_id = "MOCKSP01"
+    activation_response = activate(debtor_service_provider_token_a, random_fiscal_code, owned_alt_sp_id)
+    assert activation_response.status_code == 201, f"Error activating debtor: {activation_response.text}"
+
+    res = get_activation_by_payer_id(debtor_service_provider_token_a, random_fiscal_code)
+    assert res.status_code == 200, f"Expected 200 but got {res.status_code}"
+    assert res.json()["payer"]["fiscalCode"] == random_fiscal_code
+    assert res.json()["payer"]["rtpSpId"] == owned_alt_sp_id
+
+
+@allure.epic("Debtor Activation")
+@allure.feature("Activation")
+@allure.story("Get Debtor activation by ID")
+@allure.title(
+    "Get by activation id returns 404 when the token subject does not own the activation's Service Provider ID"
+)
+@allure.tag("functional", "unhappy_path", "activation", "debtor_activation", "ownership")
+@pytest.mark.auth
+@pytest.mark.activation
+@pytest.mark.unhappy_path
+def test_get_activation_by_id_not_owned_service_provider_id_not_found(
+    debtor_service_provider_token_a, debtor_service_provider_token_b, random_fiscal_code
+):
+
+    activation_response = activate(debtor_service_provider_token_a, random_fiscal_code, "MOCKSP01")
+    assert activation_response.status_code == 201, f"Error activating debtor: {activation_response.text}"
+    activation_id = activation_response.headers["Location"].split("/")[-1]
+
+    res = get_activation_by_id(debtor_service_provider_token_b, activation_id)
+    assert res.status_code == 404, f"Expected 404 for not-owned spId, got {res.status_code}: {res.text}"
+
+
+@allure.epic("Debtor Activation")
+@allure.feature("Activation")
+@allure.story("Get Debtor activation by Payer ID")
+@allure.title("Find by payer id returns 404 when the token subject does not own the activation's Service Provider ID")
+@allure.tag("functional", "unhappy_path", "activation", "debtor_activation", "ownership")
+@pytest.mark.auth
+@pytest.mark.activation
+@pytest.mark.unhappy_path
+def test_get_activation_by_payer_id_not_owned_service_provider_id_not_found(
+    debtor_service_provider_token_a, debtor_service_provider_token_b, random_fiscal_code
+):
+
+    activation_response = activate(debtor_service_provider_token_a, random_fiscal_code, "MOCKSP01")
+    assert activation_response.status_code == 201, f"Error activating debtor: {activation_response.text}"
+
+    res = get_activation_by_payer_id(debtor_service_provider_token_b, random_fiscal_code)
+    assert res.status_code == 404, f"Expected 404 for not-owned spId, got {res.status_code}: {res.text}"

--- a/functional-tests/tests/activation/test_debtor_activation_payer_status.py
+++ b/functional-tests/tests/activation/test_debtor_activation_payer_status.py
@@ -34,7 +34,7 @@ and is extended with structural edge cases from the Italian CF/PIVA specificatio
 import allure
 import pytest
 
-from api.debtor_activation_api import get_activation_status_by_fiscal_code
+from api.debtor_activation_api import activate, get_activation_status_by_fiscal_code
 from api.debtor_deactivation_api import deactivate
 from utils.dataset_payer_id_invalid import INVALID_PAYER_IDS
 
@@ -271,3 +271,49 @@ def test_get_activation_status_empty_payer_id(debtor_service_provider_token_a):
     """Querying activation status with an empty payerId must be rejected with 404."""
     res = get_activation_status_by_fiscal_code(debtor_service_provider_token_a, "")
     assert res.status_code == 404, f"Expected 404 Not Found but got {res.status_code}: {res.text}"
+
+
+@allure.epic("Debtor Activation")
+@allure.feature("Payer Status")
+@allure.story("Get Activation Status by Fiscal Code")
+@allure.title("An active payer returns isActive true when activated under an owned but distinct Service Provider ID")
+@allure.tag("functional", "happy_path", "activation", "payer_status", "ownership")
+@pytest.mark.activation
+@pytest.mark.happy_path
+def test_get_activation_status_active_payer_owned_alt_service_provider_id(
+    debtor_service_provider_token_a, random_fiscal_code
+):
+    """MOCKSP04 owns MOCKSP01 as well as its own spId; status must reflect the activation either way."""
+
+    owned_alt_sp_id = "MOCKSP01"
+    activation_response = activate(debtor_service_provider_token_a, random_fiscal_code, owned_alt_sp_id)
+    assert activation_response.status_code == 201, f"Error activating debtor: {activation_response.text}"
+
+    res = get_activation_status_by_fiscal_code(debtor_service_provider_token_a, random_fiscal_code)
+    assert res.status_code == 200, f"Expected 200 but got {res.status_code}: {res.text}"
+    assert res.json()["isActive"] is True
+
+
+@allure.epic("Debtor Activation")
+@allure.feature("Payer Status")
+@allure.story("Get Activation Status by Fiscal Code")
+@allure.title(
+    "Get payer status returns isActive false when the token subject does not own the activation's Service Provider ID"
+)
+@allure.tag("functional", "unhappy_path", "activation", "payer_status", "ownership")
+@pytest.mark.activation
+@pytest.mark.unhappy_path
+def test_get_activation_status_not_owned_service_provider_id_returns_inactive(
+    debtor_service_provider_token_a, debtor_service_provider_token_b, random_fiscal_code
+):
+    """Same privacy rule as the cross-SP case: no explicit error, isActive is just false."""
+    activation_response = activate(debtor_service_provider_token_a, random_fiscal_code, "MOCKSP01")
+    assert activation_response.status_code == 201, f"Error activating debtor: {activation_response.text}"
+
+    status_response = get_activation_status_by_fiscal_code(debtor_service_provider_token_b, random_fiscal_code)
+    assert status_response.status_code == 200, (
+        f"Expected 200 but got {status_response.status_code}: {status_response.text}"
+    )
+    assert status_response.json()["isActive"] is False, (
+        f"Expected isActive=false for not-owned spId (privacy rule) but got: {status_response.json()}"
+    )

--- a/functional-tests/tests/activation/test_debtor_deactivation.py
+++ b/functional-tests/tests/activation/test_debtor_deactivation.py
@@ -70,3 +70,48 @@ def test_deactivate_debtor_wrong_service_provider(
     assert deactivation_response.status_code == 404, (
         f"Expected 404 for deactivation by wrong service provider, got {deactivation_response.status_code}"
     )
+
+
+@allure.epic("Debtor Deactivation")
+@allure.feature("Deactivation")
+@allure.story("Debtor deactivation")
+@allure.title("A debtor activated with an owned but distinct Service Provider ID is deactivated")
+@allure.tag("functional", "happy_path", "deactivation", "debtor_deactivation", "ownership")
+@pytest.mark.auth
+@pytest.mark.deactivation
+@pytest.mark.happy_path
+def test_deactivate_debtor_owned_but_distinct_service_provider_id(debtor_service_provider_token_a, random_fiscal_code):
+
+    owned_alt_sp_id = "MOCKSP01"
+    activation_response = activate(debtor_service_provider_token_a, random_fiscal_code, owned_alt_sp_id)
+    assert activation_response.status_code == 201, "Error activating debtor"
+
+    location = activation_response.headers["Location"]
+    activation_id = location.split("/")[-1]
+
+    deactivation_response = deactivate(debtor_service_provider_token_a, activation_id)
+    assert deactivation_response.status_code == 204, (
+        f"Error deactivating debtor, expected 204 but got {deactivation_response.status_code}"
+    )
+
+
+@allure.feature("Deactivation")
+@allure.story("Debtor deactivation")
+@allure.title("Deactivation returns 404 when the token subject does not own the activation's Service Provider ID")
+@pytest.mark.auth
+@pytest.mark.deactivation
+@pytest.mark.unhappy_path
+def test_deactivate_debtor_not_owned_service_provider_id(
+    debtor_service_provider_token_a, debtor_service_provider_token_b, random_fiscal_code
+):
+
+    activation_response = activate(debtor_service_provider_token_a, random_fiscal_code, "MOCKSP01")
+    assert activation_response.status_code == 201, "Error activating debtor"
+
+    location = activation_response.headers["Location"]
+    activation_id = location.split("/")[-1]
+
+    deactivation_response = deactivate(debtor_service_provider_token_b, activation_id)
+    assert deactivation_response.status_code == 404, (
+        f"Expected 404 for deactivation with not-owned Service Provider ID, got {deactivation_response.status_code}"
+    )

--- a/functional-tests/tests/takeover/test_debtor_takeover.py
+++ b/functional-tests/tests/takeover/test_debtor_takeover.py
@@ -5,9 +5,10 @@ from datetime import UTC, datetime
 import allure
 import pytest
 
-from api.debtor_activation_api import get_activation_by_id, get_activation_by_payer_id
+from api.debtor_activation_api import activate, get_activation_by_id, get_activation_by_payer_id
 from api.debtor_takeover_api import send_takeover_notification, takeover_activation
 from config.configuration import secrets
+from utils.activation_error_codes import ActivationErrorCode
 from utils.activation_helpers import activate_with_sp_a, activate_with_sp_b
 from utils.http_utils import extract_id_from_location
 
@@ -66,6 +67,44 @@ def test_takeover_flow(random_fiscal_code, debtor_service_provider_token_a, debt
     new_sp = get_after_takeover.json()["payer"]["rtpSpId"]
     assert new_sp == secrets.debtor_service_provider_B.service_provider_id, (
         f"Takeover failed. Expected service provider {secrets.debtor_service_provider_B.service_provider_id}, got {new_sp}"
+    )
+
+
+@allure.epic("Debtor Takeover")
+@allure.feature("Takeover happy path")
+@allure.title("Test Takeover Redemption Assigns the OTP's Owned Service Provider ID")
+@allure.story("Takeover redemption using a Service Provider ID owned but not represented by the redeemer")
+@allure.tag("functional", "happy_path", "activation", "takeover", "ownership")
+@pytest.mark.functional
+@pytest.mark.happy_path
+def test_takeover_redemption_assigns_otp_owned_service_provider_id(random_fiscal_code, debtor_service_provider_token_a):
+    """MOCKSP04 owns both its own spId and MOCKSP01; redeeming an OTP scoped to MOCKSP01 must
+    assign MOCKSP01 to the new activation, not MOCKSP04 (the redeemer's own tspId)."""
+
+    owned_alt_sp_id = "MOCKSP01"
+    bait_response = activate(
+        debtor_service_provider_token_a, random_fiscal_code, secrets.debtor_service_provider.service_provider_id
+    )
+    assert bait_response.status_code == 201, f"Error activating bait debtor: {bait_response.text}"
+
+    conflict_response = activate(debtor_service_provider_token_a, random_fiscal_code, owned_alt_sp_id)
+    assert conflict_response.status_code == 409, (
+        f"Expected 409 conflict (takeover trigger), got {conflict_response.status_code}: {conflict_response.text}"
+    )
+    otp = extract_id_from_location(conflict_response.headers.get("Location"))
+    assert otp is not None, "Missing/invalid Location header (expected OTP for takeover trigger)"
+
+    takeover_response = takeover_activation(debtor_service_provider_token_a, random_fiscal_code, owned_alt_sp_id, otp)
+    assert takeover_response.status_code == 201, f"Failed to takeover: {takeover_response.text}"
+    new_activation_id = extract_id_from_location(takeover_response.headers.get("Location"))
+    assert new_activation_id is not None, "Missing Location header in takeover response"
+
+    time.sleep(1)
+
+    get_after_takeover = get_activation_by_id(debtor_service_provider_token_a, new_activation_id)
+    assert get_after_takeover.status_code == 200, f"Failed to get activation after takeover: {get_after_takeover.text}"
+    assert get_after_takeover.json()["payer"]["rtpSpId"] == owned_alt_sp_id, (
+        "Takeover must assign the OTP's owned Service Provider ID, not the redeemer's own tspId"
     )
 
 
@@ -331,3 +370,35 @@ def test_takeover_no_sense_body_but_valid_syntax(
         include_payload=True,
     )
     assert bad.status_code == 400, f"Expected 400 for nonsensical body, got {bad.status_code}: {bad.text}"
+
+
+@allure.epic("Debtor Takeover")
+@allure.feature("Takeover unhappy path")
+@allure.title("Test Takeover Fails when Redeemer Does Not Own the OTP's Service Provider ID")
+@allure.story("Takeover fails because the redeemer does not own the OTP's Service Provider ID")
+@pytest.mark.functional
+@allure.tag("functional", "unhappy_path", "activation", "takeover", "ownership")
+@pytest.mark.unhappy_path
+def test_takeover_redeemer_not_owning_otp_service_provider_id_forbidden(
+    random_fiscal_code, debtor_service_provider_token_a, debtor_service_provider_token_b
+):
+    """MOCKSP04 owns MOCKSP01 and triggers the OTP; FAKESP01, which owns neither, must be rejected
+    with an explicit ownership error, not merely a generic 403."""
+
+    owned_alt_sp_id = "MOCKSP01"
+    bait_response = activate(
+        debtor_service_provider_token_a, random_fiscal_code, secrets.debtor_service_provider.service_provider_id
+    )
+    assert bait_response.status_code == 201, f"Error activating bait debtor: {bait_response.text}"
+
+    conflict_response = activate(debtor_service_provider_token_a, random_fiscal_code, owned_alt_sp_id)
+    assert conflict_response.status_code == 409, (
+        f"Expected 409 conflict (takeover trigger), got {conflict_response.status_code}: {conflict_response.text}"
+    )
+    otp = extract_id_from_location(conflict_response.headers.get("Location"))
+    assert otp is not None, "Missing/invalid Location header (expected OTP for takeover trigger)"
+
+    res = takeover_activation(debtor_service_provider_token_b, random_fiscal_code, owned_alt_sp_id, otp)
+    assert res.status_code == 403, f"Expected 403 Forbidden, got {res.status_code}: {res.text}"
+    assert res.json()["errors"][0]["code"] == ActivationErrorCode.SERVICE_PROVIDER_ID_NOT_OWNED.code
+    assert res.json()["errors"][0]["description"] == ActivationErrorCode.SERVICE_PROVIDER_ID_NOT_OWNED.description

--- a/utils/activation_error_codes.py
+++ b/utils/activation_error_codes.py
@@ -11,6 +11,7 @@ class ActivationErrorCode(Enum):
     INVALID_FISCAL_CODE_FORMAT = ("01021002E", "Invalid fiscal code format.")
     INVALID_SERVICE_PROVIDER_ID_FORMAT = ("01021003E", "Invalid RTP Service Provider ID format.")
     USER_ALREADY_ACTIVE = ("01031006E", "User is already active")
+    SERVICE_PROVIDER_ID_NOT_OWNED = ("01011006F", "Payer's RTP Service Provider ID is not owned by the token subject.")
 
     def __init__(self, code: str, description: str):
         self.code = code


### PR DESCRIPTION
### Description

This PR adds functional test coverage for RTP Service Provider ID **ownership**: a token subject (tspId) may act on behalf of an RTP Service Provider ID different from its own, as long as the Service Providers registry grants it ownership of that spId. 
Until now the test suite only exercised the case where a tspId acts on its own spId (happy path) or on a completely unrelatedone it doesn't own (cross-SP security checks). 
These tests cover the additional case where a tspId owns *more than one* spId, and verify both the happy path (activation, retrieval, takeover, deactivation using an owned-but-distinct spId) and the unhappy paths (a not-owned or nonexistent spId, and privacy-preserving responses for resources owned by someone else).

### List of changes

- `utils/activation_error_codes.py`: added `SERVICE_PROVIDER_ID_NOT_OWNED` (`01011006F`,
  "Payer's RTP Service Provider ID is not owned by the token subject."), returned when the
  ownership check fails on activation or on takeover redemption.
- `functional-tests/tests/activation/test_debtor_activation_create.py`:
  - `test_activate_debtor_with_owned_but_distinct_service_provider_id` — activation succeeds when
    the target spId (`MOCKSP01`) differs from the token's own spId but is owned by it.
  - `test_activate_debtor_forbidden_for_not_owned_service_provider_id` — 403 when the target spId
    is owned by someone else.
  - `test_activate_debtor_forbidden_for_nonexistent_service_provider_id` — 403 with the same error
    code when the target spId doesn't exist in the registry at all.
- `functional-tests/tests/activation/test_debtor_activation_get.py`:
  - `test_get_activation_by_id_owned_but_distinct_service_provider_id` /
    `test_get_activation_by_payer_id_owned_but_distinct_service_provider_id` — both lookups
    succeed for an activation on an owned-but-distinct spId.
  - `test_get_activation_by_id_not_owned_service_provider_id_not_found` /
    `test_get_activation_by_payer_id_not_owned_service_provider_id_not_found` — 404 (not 403) when
    the caller doesn't own the activation's spId, consistent with the existing cross-SP privacy
    strategy that hides resource existence rather than revealing an ownership mismatch.
- `functional-tests/tests/activation/test_debtor_activation_payer_status.py`:
  - `test_get_activation_status_active_payer_owned_alt_service_provider_id` — `isActive: true` for
    an owned-but-distinct spId.
  - `test_get_activation_status_not_owned_service_provider_id_returns_inactive` — `isActive: false`
    (no explicit error) when the caller doesn't own the activation's spId, mirroring the existing
    cross-SP privacy rule for this endpoint.
- `functional-tests/tests/activation/test_debtor_deactivation.py`:
  - `test_deactivate_debtor_owned_but_distinct_service_provider_id` — 204 when deactivating an
    activation on an owned-but-distinct spId.
  - `test_deactivate_debtor_not_owned_service_provider_id` — 404 when the caller doesn't own the
    activation's spId.
- `functional-tests/tests/takeover/test_debtor_takeover.py`:
  - `test_takeover_redemption_assigns_otp_owned_service_provider_id` — a tspId that owns two spIds
    can trigger a takeover conflict against itself (bait activation on its own spId, conflicting
    activation on the owned-but-distinct spId) and redeem the resulting OTP; the new activation's
    `rtpSpId` is asserted to equal the OTP's owned spId, not the redeemer's own tspId.
  - `test_takeover_redeemer_not_owning_otp_service_provider_id_forbidden` — 403 with an explicit
    error body check (`SERVICE_PROVIDER_ID_NOT_OWNED`) when the redeemer doesn't own the OTP's
    target spId.

### Motivation and context

The Activation/Takeover APIs support an ownership model where a single tspId can be authorized for multiple RTP Service Provider IDs, not just its own. 
This behavior was previously untested: all existing activation and takeover tests only covered a tspId acting on its own spId, or on an spId it has no relationship to at all (plain cross-SP checks, or a syntactically-wrong spId as in
`test_fail_activate_debtor_incongruent_service_provider`). These new tests close that gap and lock in the expected contract: ownership, not identity, gates access; a missing spId in the registry fails the same way as one owned by someone else (no information disclosure); and existing resources stay hidden (404 / `isActive: false`) from tspIds that don't own them, rather than surfacing an explicit permission error.

### Aggregation level

- [ ] Test case
- [x] Test suite

### Test type

- [x] Functional test
- [ ] Bdd test
- [ ] Performance
- [ ] End to end
- [ ] Performance

### Type of changes

- [x] Add new test case/suite
- [ ] Modify existing test case/suite

### Test Results

- [x] Success
- [ ] Failure
- [ ] Poor performance
- [ ] Good performance

### Did you update secrets accordingly?

- [ ] Yes
  - [ ] `.secrets_template.yaml`
  - [ ] Pipelines' secure file
  - [ ] Confluence
- [x] Not needed
- [ ] No (_please provide further information_)

### Did you update dependencies accordingly?

- [ ] Yes (which requirements.txt did you update?)
- [x] Not needed

### Other information

None.