### PR TITLE
feat: [SRTP-2124] add body to delete activations

### DIFF
--- a/functional-tests/tests/activation/test_debtor_deactivation.py
+++ b/functional-tests/tests/activation/test_debtor_deactivation.py
@@ -47,6 +47,14 @@ def test_deactivate_nonexistent_debtor(debtor_service_provider_token_a):
         f"Expected 404 status code for non-existent activation, got {deactivation_response.status_code}"
     )
 
+    error_body = deactivation_response.json()
+    assert "errors" in error_body
+    assert isinstance(error_body["errors"], list)
+    assert len(error_body["errors"]) > 0
+    for err in error_body["errors"]:
+        assert err["code"] == "01041000E"
+        assert err["description"] == "Activation not found."
+
 
 @allure.feature("Deactivation")
 @allure.story("Debtor deactivation")


### PR DESCRIPTION
### Description

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Adds assertions to verify the error response body on `DELETE /activations/{activationId}` for non-existent resources.
### List of changes

<!--- Describe your changes in detail -->

- Updated `test_deactivate_nonexistent_debtor` in `test_debtor_deactivation.py` to assert the 404 response body has code `01041000E` and description `"Activation not found."`.

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

Ensures that the functional test suite verifies the structured error body returned by the API on deactivation failure (404), keeping the tests aligned with the updated controller response.

### Aggregation level

<!--- Did you write a single reusable test case, or a full test suite?  -->

- [ ] Test case
- [x] Test suite

### Test type

- [x] Functional test
- [ ] Bdd test
- [ ] Performance
- [ ] End to end
- [ ] Performance

### Type of changes

- [ ] Add new test case/suite
- [x] Modify existing test case/suite

### Test Results

- [x] Success
- [ ] Failure
- [ ] Poor performance
- [ ] Good performance

### Did you update secrets accordingly?

- [ ] Yes
  - [ ] `.secrets_template.yaml`
  - [ ] Pipelines' secure file
  - [ ] Confluence
- [x] Not needed
- [ ] No (_please provide further information_)

### Did you update dependencies accordingly?

- [ ] Yes (which requirements.txt did you update?)
<!--- Describe which requirements.txt did you update -->
- [x] Not needed


### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
